### PR TITLE
Improve docs phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="guarahooks - Copy-and-paste hooks into your apps." src="./public/og.webp" width="100%" style="border-radius: 16px">
+<img alt="Screenshot of the guarahooks hero with the copy-and-paste tagline" src="./public/og.webp" width="100%" style="border-radius: 16px">
 
 <div align="center">
   <a href="https://github.com/h3rmel/guarahooks"><img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/h3rmel/guarahooks?style=for-the-badge"></a>
@@ -7,7 +7,7 @@
 
 # guarahooks
 
-A set of reusable and customizable hooks that you can copy-and-paste into your apps. Free. Open Source and Open Code.
+A free, open-source collection of reusable React hooks you can copy and paste into your apps.
 
 ## Documentation
 
@@ -15,7 +15,7 @@ Visit https://guarahooks.com to view the documentation.
 
 ## Contributing
 
-Visit our [contributing guide](https://github.com/h3rmel/guarahooks/blob/main/CONTRIBUTING.md) to learn how to contribute. It only takes ~5 minutes to add a hook!
+See our [contributing guide](https://github.com/h3rmel/guarahooks/blob/main/CONTRIBUTING.md) to learn how to contribute. Adding a hook usually takes about five minutes.
 
 ## Authors
 

--- a/config/site.ts
+++ b/config/site.ts
@@ -2,7 +2,7 @@ export const siteConfig = {
   name: 'guarahooks',
   url: 'https://guarahooks.com',
   description:
-    'A set of reusable and customizable hooks that you can copy-and-paste into your apps. Free. Open Source and Open Code.',
+    'A free, open-source collection of reusable React hooks you can copy and paste into your apps.',
   links: {
     github: 'https://github.com/h3rmel/guarahooks',
   },

--- a/content/docs/cli.mdx
+++ b/content/docs/cli.mdx
@@ -5,7 +5,7 @@ description: Use the guarahooks CLI to add hooks to your project.
 
 ## add
 
-Use the `add` command to add hook and dependencies to your project.
+Use the `add` command to install a hook along with its dependencies.
 
 ```bash
 npx guara-cli add [hook]

--- a/content/docs/hooks/index.mdx
+++ b/content/docs/hooks/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hooks
-description: Here you can find all the hooks available in the library. We are working on adding more hooks.
+description: Browse all hooks in the library—we're continually adding more.
 ---
 
 <HooksList />

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,35 +1,35 @@
 ---
 title: Introduction
-description: A collection of type-safe, reusable and customizable hooks to build your applications faster.
+  description: A collection of type-safe, reusable, and customizable hooks to build your applications faster.
 ---
 
-_guarahooks_ is an open collection of custom React hooks with focus on performance, type-safety and reusability. It provides a wide range of hooks for common use cases.
+guarahooks is an open-source collection of custom React hooks focused on performance, type safety, and reusability. It offers hooks for many common use cases.
 
 ## How does it work?
 
-All the hooks created are converted into JSON files that follow the [Shadcn UI](https://ui.shadcn.com) schema. With this, the hooks can be used in any project that uses the [Shadcn UI CLI](https://ui.shadcn.com/cli) (or use the [Guara CLI](./docs/cli) to avoid the need to install the Shadcn UI CLI). In essence, when you need a hook, you simply choose from the list of hooks and copy-and-paste into your projects by CLI or manually.
+Each hook is stored as a JSON file that follows the [shadcn/ui](https://ui.shadcn.com) schema. This lets you use the hooks with the Shadcn UI CLI or the [Guara CLI](./docs/cli) if you prefer not to install shadcn/ui's CLI. When you need a hook, simply choose one and copy it into your project using the CLI or manually.
 
 ## Why use this collection?
 
-By using this collection, you can:
+Using this collection lets you:
 
-- Reduce the amount of code you write
-- Reduce the amount of time spent on writing hooks
-- Reduce the amount of time spent on debugging hooks
-- Reduce the amount of time spent on reading documentation
-- Reduce the amount of time spent on searching for hooks
+- Reduce the code you need to write
+- Spend less time writing hooks
+- Spend less time debugging hooks
+- Spend less time reading documentation
+- Spend less time searching for hooks
 
-And more importantly, you can: **Focus on building your application faster!**
+Most importantly, you can **focus on building your application faster!**
 
 ## Key Features
 
-- Reusability: guarahooks is designed to be reusable, allowing you to reuse the same hook in multiple ways.
-- Type-safety: guarahooks is designed to be type-safe, allowing you to catch errors at compile time.
-- Performant: guarahooks is designed to be performant, ensuring fast and efficient execution.
-- Documentation: guarahooks has a simple and comprehensive documentation with examples.
+- Reusability: guarahooks is designed for reuse, letting you apply the same hook in multiple ways.
+- Type safety: catch errors at compile time.
+- Performance: optimized for fast, efficient execution.
+- Documentation: simple, comprehensive docs with examples.
 
 ## Ready to get started?
 
 Check out the [installation guide](/docs/installation) to get started.
 
-This library is heavily inspired by [https://ui.shadcn.com](https://ui.shadcn.com) and [https://magicui.design](https://magicui.design).
+This library is heavily inspired by [shadcn/ui](https://ui.shadcn.com) and [magicui.design](https://magicui.design).

--- a/content/docs/installation/index.mdx
+++ b/content/docs/installation/index.mdx
@@ -3,13 +3,13 @@ title: Installation
 description: How to install dependencies and use the library
 ---
 
-We have the same installation process as [shadcn/ui](https://ui.shadcn.com/docs/installation/). So, let's dive in!
+Installation works just like [shadcn/ui](https://ui.shadcn.com/docs/installation/). Here's how to get started:
 
 <Steps>
 
 ### Create project
 
-Run the `init` command to create a new Next.js project or to setup an existing one:
+Run the `init` command to create a new Next.js project or to set up an existing one:
 
 ```bash
 npx shadcn@latest init

--- a/content/docs/resources.mdx
+++ b/content/docs/resources.mdx
@@ -3,7 +3,7 @@ title: Resources
 description: A list of resources that can help you learn more about custom hooks.
 ---
 
-There are some useful resources that can help you learn to build custom hooks. Here are a list of them:
+Here are some useful resources to help you learn more about custom hooks:
 
 - [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)
 - [Built-in React Hooks](https://react.dev/reference/react/hooks)

--- a/content/docs/v0.mdx
+++ b/content/docs/v0.mdx
@@ -3,7 +3,7 @@ title: Open in v0
 description: Open hooks in v0 for customization.
 ---
 
-Every hook in guarahooks.com is editable on [v0 by vercel](https://v0.dev). This allows you to easily customize the hooks and paste into your apps.
+Every hook on guarahooks.com can be opened in [v0 by Vercel](https://v0.dev), making it easy to customize and paste them into your apps.
 
 <a href="https://vercel.com/signup?utm_source=shad&utm_medium=web&utm_campaign=docs_cta_signup">
   <Image
@@ -23,8 +23,8 @@ Every hook in guarahooks.com is editable on [v0 by vercel](https://v0.dev). This
   <span className="sr-only">Open in v0</span>
 </a>
 
-To use v0, sign-up for a free [Vercel account here](https://vercel.com/signup?utm_source=shad&utm_medium=web&utm_campaign=docs_cta_signup). In addition to v0, this gives you free access to Vercel's frontend cloud platform by the creators of Next.js, where you can deploy and host your project for free.
+To use v0, sign up for a free [Vercel account here](https://vercel.com/signup?utm_source=shad&utm_medium=web&utm_campaign=docs_cta_signup). You'll also receive free access to Vercel's frontend cloud platform, created by the makers of Next.js, where you can deploy and host your project.
 
-Learn more about getting started with [Vercel here](https://vercel.com/docs/getting-started-with-vercel?utm_source=shadcn_site&utm_medium=web&utm_campaign=docs_cta_about_vercel).
+Learn more about getting started with [Vercel](https://vercel.com/docs/getting-started-with-vercel?utm_source=shadcn_site&utm_medium=web&utm_campaign=docs_cta_about_vercel).
 
 Learn more about getting started with [v0 here](https://v0.dev/faq).

--- a/content/showcases/guarahooks.mdx
+++ b/content/showcases/guarahooks.mdx
@@ -1,10 +1,10 @@
 ---
 title: guarahooks.com
-description: Set of reusable and customizable hooks that you can copy-and-paste into your apps. Free. Open Source and Open Code.
+description: A free, open-source collection of reusable React hooks you can copy and paste into your apps.
 image: /showcase/guarahooks.png
 href: https://guarahooks.com
 featured: true
-affiliation: Open Source Project
+affiliation: Open source project
 ---
 
-An open-source and free collection of hooks that you can copy-and-paste into your applications. The application is used by +1000 developers and is growing every day.
+An open-source collection of React hooks you can copy and paste into your apps. Over 1,000 developers use the project, and the community keeps growing.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,16 +1,14 @@
 # guara-cli
 
-A CLI for adding hooks to your project.
+A CLI for installing hooks in your project.
 
 ## Usage
 
-There's no need to initialize anything right now. Just start adding the hooks to your project.
+No initialization needed—just start adding hooks to your project.
 
 ## add
 
-Use the `add` command to add hooks to your project.
-
-The `add` command adds a hook to your project and install all required dependencies.
+Use the `add` command to install a hook and any required dependencies in your project.
 
 ```bash
 npx guara-cli add [hook]
@@ -22,7 +20,7 @@ npx guara-cli add [hook]
 npx guara-cli add use-window-size
 ```
 
-You can also run the command without any arguments to view a list of all available components:
+Run the command without arguments to list available hooks:
 
 ```bash
 npx guara-cli add


### PR DESCRIPTION
## Summary
- mention React in descriptions and tagline
- clarify intro, CLI, installation, and resources wording
- refine v0 info and hooks index description

## Testing
- `pnpm i`
- `pnpm format:write` *(fails: [prettier-plugin-sort-imports] import sorting aborted due to babel parsing error)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684227ad0f00832683bcb8e0318dfb0f