### PR TITLE
Add additional payment gateway hooks

### DIFF
--- a/config/docs.ts
+++ b/config/docs.ts
@@ -251,6 +251,187 @@ export const docsConfig: DashboardConfig = {
       ],
     },
     {
+      title: 'Payments',
+      icon: 'Tools',
+      items: [
+        {
+          title: 'use-stripe',
+          href: '/docs/hooks/use-stripe',
+          label: 'New',
+        },
+        {
+          title: 'use-mercadopago',
+          href: '/docs/hooks/use-mercadopago',
+          label: 'New',
+        },
+        {
+          title: 'use-abacate-pay',
+          href: '/docs/hooks/use-abacate-pay',
+          label: 'New',
+        },
+        {
+          title: 'use-lemon-squeezy',
+          href: '/docs/hooks/use-lemon-squeezy',
+          label: 'New',
+        },
+        {
+          title: 'use-paypal',
+          href: '/docs/hooks/use-paypal',
+          label: 'New',
+        },
+        {
+          title: 'use-wide-pay',
+          href: '/docs/hooks/use-wide-pay',
+          label: 'New',
+        },
+        {
+          title: 'use-vindi',
+          href: '/docs/hooks/use-vindi',
+          label: 'New',
+        },
+        {
+          title: 'use-apple-pay',
+          href: '/docs/hooks/use-apple-pay',
+          label: 'New',
+        },
+        {
+          title: 'use-amazon-pay',
+          href: '/docs/hooks/use-amazon-pay',
+          label: 'New',
+        },
+        {
+          title: 'use-ali-pay',
+          href: '/docs/hooks/use-ali-pay',
+          label: 'New',
+        },
+        {
+          title: 'use-two-checkout',
+          href: '/docs/hooks/use-two-checkout',
+          label: 'New',
+        },
+        {
+          title: 'use-stax-pay',
+          href: '/docs/hooks/use-stax-pay',
+          label: 'New',
+        },
+        {
+          title: 'use-square',
+          href: '/docs/hooks/use-square',
+          label: 'New',
+        },
+        {
+          title: 'use-payoneer',
+          href: '/docs/hooks/use-payoneer',
+          label: 'New',
+        },
+        {
+          title: 'use-pagseguro',
+          href: '/docs/hooks/use-pagseguro',
+          label: 'New',
+        },
+        {
+          title: 'use-pagbank',
+          href: '/docs/hooks/use-pagbank',
+          label: 'New',
+        },
+        {
+          title: 'use-iugu',
+          href: '/docs/hooks/use-iugu',
+          label: 'New',
+        },
+        {
+          title: 'use-pagarme',
+          href: '/docs/hooks/use-pagarme',
+          label: 'New',
+        },
+        {
+          title: 'use-transire',
+          href: '/docs/hooks/use-transire',
+          label: 'New',
+        },
+        {
+          title: 'use-pag-brasil',
+          href: '/docs/hooks/use-pag-brasil',
+          label: 'New',
+        },
+        {
+          title: 'use-stone',
+          href: '/docs/hooks/use-stone',
+          label: 'New',
+        },
+        {
+          title: 'use-superlogica',
+          href: '/docs/hooks/use-superlogica',
+          label: 'New',
+        },
+        {
+          title: 'use-yapay',
+          href: '/docs/hooks/use-yapay',
+          label: 'New',
+        },
+        {
+          title: 'use-zigpay',
+          href: '/docs/hooks/use-zigpay',
+          label: 'New',
+        },
+        {
+          title: 'use-boa-compra',
+          href: '/docs/hooks/use-boa-compra',
+          label: 'New',
+        },
+        {
+          title: 'use-celcoin',
+          href: '/docs/hooks/use-celcoin',
+          label: 'New',
+        },
+        {
+          title: 'use-acqio',
+          href: '/docs/hooks/use-acqio',
+          label: 'New',
+        },
+        {
+          title: 'use-cappta',
+          href: '/docs/hooks/use-cappta',
+          label: 'New',
+        },
+        {
+          title: 'use-ebanx',
+          href: '/docs/hooks/use-ebanx',
+          label: 'New',
+        },
+        {
+          title: 'use-gerenciament',
+          href: '/docs/hooks/use-gerenciament',
+          label: 'New',
+        },
+        {
+          title: 'use-juno',
+          href: '/docs/hooks/use-juno',
+          label: 'New',
+        },
+        {
+          title: 'use-koin',
+          href: '/docs/hooks/use-koin',
+          label: 'New',
+        },
+        {
+          title: 'use-mova',
+          href: '/docs/hooks/use-mova',
+          label: 'New',
+        },
+        {
+          title: 'use-cloud-walk',
+          href: '/docs/hooks/use-cloud-walk',
+          label: 'New',
+        },
+        {
+          title: 'use-efi-bank',
+          href: '/docs/hooks/use-efi-bank',
+          label: 'New',
+        },
+      ],
+    },
+    {
       title: 'Lifecycle',
       icon: 'Refresh',
       items: [

--- a/content/docs/hooks/use-abacate-pay.mdx
+++ b/content/docs/hooks/use-abacate-pay.mdx
@@ -1,0 +1,71 @@
+---
+title: useAbacatePay
+date: 2025-06-27
+description: Generic hook for the fictional AbacatePay gateway.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-abacate-pay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-abacate-pay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-abacate-pay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Props
+
+| Prop        | Type      | Default                               | Description                        |
+| ----------- | --------- | ------------------------------------- | ---------------------------------- |
+| `publicKey` | `string`  | -                                     | AbacatePay public key              |
+| `scriptUrl` | `string`  | `'https://cdn.abacatepay.com/sdk.js'` | SDK script URL                     |
+| `autoInit`  | `boolean` | `true`                                | Load script automatically on mount |
+
+## Data
+
+| Prop           | Type                                  | Description                          |
+| -------------- | ------------------------------------- | ------------------------------------ |
+| `abacate`      | `any`                                 | AbacatePay instance                  |
+| `loading`      | `boolean`                             | Indicates if the SDK is loading      |
+| `error`        | `Error \| null`                       | Error loading the SDK                |
+| `init`         | `() => Promise<void>`                 | Manually initialize the SDK          |
+| `openCheckout` | `(sessionId: string) => void`         | Open checkout with the given session |
+| `getStatus`    | `(paymentId: string) => Promise<any>` | Fetch payment status                 |
+
+## Examples
+
+### Basic Usage
+
+```tsx
+const { openCheckout } = useAbacatePay({
+  publicKey: 'test_public_key',
+});
+
+return <Button onClick={() => openCheckout('session_123')}>Pay</Button>;
+```

--- a/content/docs/hooks/use-acqio.mdx
+++ b/content/docs/hooks/use-acqio.mdx
@@ -1,0 +1,40 @@
+---
+title: useAcqio
+date: 2025-06-27
+description: Acqio payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-acqio-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-acqio"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-acqio" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-adyen.mdx
+++ b/content/docs/hooks/use-adyen.mdx
@@ -1,0 +1,40 @@
+---
+title: useAdyen
+date: 2025-06-27
+description: Adyen checkout integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-adyen-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-adyen"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-adyen" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-ali-pay.mdx
+++ b/content/docs/hooks/use-ali-pay.mdx
@@ -1,0 +1,40 @@
+---
+title: useAliPay
+date: 2025-06-27
+description: Wrapper for the AliPay JS bridge.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-ali-pay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-ali-pay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-ali-pay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-amazon-pay.mdx
+++ b/content/docs/hooks/use-amazon-pay.mdx
@@ -1,0 +1,40 @@
+---
+title: useAmazonPay
+date: 2025-06-27
+description: Hook for the Amazon Pay SDK.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-amazon-pay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-amazon-pay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-amazon-pay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-apple-pay.mdx
+++ b/content/docs/hooks/use-apple-pay.mdx
@@ -1,0 +1,40 @@
+---
+title: useApplePay
+date: 2025-06-27
+description: Apple Pay integration using the Payment Request API.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-apple-pay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-apple-pay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-apple-pay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-barte.mdx
+++ b/content/docs/hooks/use-barte.mdx
@@ -1,0 +1,40 @@
+---
+title: useBarte
+date: 2025-06-27
+description: Barte payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-barte-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-barte"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-barte" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-boa-compra.mdx
+++ b/content/docs/hooks/use-boa-compra.mdx
@@ -1,0 +1,40 @@
+---
+title: useBoaCompra
+date: 2025-06-27
+description: Boa Compra payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-boa-compra-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-boa-compra"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-boa-compra" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-braintree.mdx
+++ b/content/docs/hooks/use-braintree.mdx
@@ -1,0 +1,40 @@
+---
+title: useBraintree
+date: 2025-06-27
+description: Braintree drop-in hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-braintree-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-braintree"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-braintree" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-braspag.mdx
+++ b/content/docs/hooks/use-braspag.mdx
@@ -1,0 +1,40 @@
+---
+title: useBraspag
+date: 2025-06-27
+description: Braspag payment helper.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-braspag-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-braspag"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-braspag" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-cappta.mdx
+++ b/content/docs/hooks/use-cappta.mdx
@@ -1,0 +1,40 @@
+---
+title: useCappta
+date: 2025-06-27
+description: Cappta payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-cappta-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-cappta"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-cappta" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-celcoin.mdx
+++ b/content/docs/hooks/use-celcoin.mdx
@@ -1,0 +1,40 @@
+---
+title: useCelcoin
+date: 2025-06-27
+description: Celcoin payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-celcoin-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-celcoin"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-celcoin" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-chargebee.mdx
+++ b/content/docs/hooks/use-chargebee.mdx
@@ -1,0 +1,40 @@
+---
+title: useChargebee
+date: 2025-06-27
+description: Chargebee JS wrapper.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-chargebee-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-chargebee"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-chargebee" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-cielo.mdx
+++ b/content/docs/hooks/use-cielo.mdx
@@ -1,0 +1,40 @@
+---
+title: useCielo
+date: 2025-06-27
+description: Cielo payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-cielo-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-cielo"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-cielo" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-clearsale.mdx
+++ b/content/docs/hooks/use-clearsale.mdx
@@ -1,0 +1,40 @@
+---
+title: useClearSale
+date: 2025-06-27
+description: ClearSale anti-fraud integration hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-clearsale-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-clearsale"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-clearsale" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-cloud-walk.mdx
+++ b/content/docs/hooks/use-cloud-walk.mdx
@@ -1,0 +1,40 @@
+---
+title: useCloudWalk
+date: 2025-06-27
+description: CloudWalk payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-cloud-walk-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-cloud-walk"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-cloud-walk" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-drip.mdx
+++ b/content/docs/hooks/use-drip.mdx
@@ -1,0 +1,40 @@
+---
+title: useDrip
+date: 2025-06-27
+description: Drip payment integration hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-drip-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-drip"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-drip" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-ebanx.mdx
+++ b/content/docs/hooks/use-ebanx.mdx
@@ -1,0 +1,40 @@
+---
+title: useEbanx
+date: 2025-06-27
+description: Ebanx payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-ebanx-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-ebanx"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-ebanx" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-efi-bank.mdx
+++ b/content/docs/hooks/use-efi-bank.mdx
@@ -1,0 +1,40 @@
+---
+title: useEfiBank
+date: 2025-06-27
+description: Efi Bank payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-efi-bank-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-efi-bank"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-efi-bank" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-equals.mdx
+++ b/content/docs/hooks/use-equals.mdx
@@ -1,0 +1,40 @@
+---
+title: useEquals
+date: 2025-06-27
+description: Equals Pay helper hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-equals-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-equals"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-equals" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-gerenciament.mdx
+++ b/content/docs/hooks/use-gerenciament.mdx
@@ -1,0 +1,40 @@
+---
+title: useGerenciament
+date: 2025-06-27
+description: Gerenciament payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-gerenciament-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-gerenciament"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-gerenciament" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-getnet.mdx
+++ b/content/docs/hooks/use-getnet.mdx
@@ -1,0 +1,40 @@
+---
+title: useGetnet
+date: 2025-06-27
+description: Getnet payment SDK hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-getnet-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-getnet"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-getnet" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-iugu.mdx
+++ b/content/docs/hooks/use-iugu.mdx
@@ -1,0 +1,40 @@
+---
+title: useIugu
+date: 2025-06-27
+description: Iugu payment integration hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-iugu-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-iugu"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-iugu" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-juno.mdx
+++ b/content/docs/hooks/use-juno.mdx
@@ -1,0 +1,40 @@
+---
+title: useJuno
+date: 2025-06-27
+description: Juno payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-juno-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-juno"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-juno" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-klap.mdx
+++ b/content/docs/hooks/use-klap.mdx
@@ -1,0 +1,40 @@
+---
+title: useKlap
+date: 2025-06-27
+description: Klap payments SDK hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-klap-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-klap"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-klap" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-koin.mdx
+++ b/content/docs/hooks/use-koin.mdx
@@ -1,0 +1,40 @@
+---
+title: useKoin
+date: 2025-06-27
+description: Koin payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-koin-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-koin"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-koin" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-lemon-squeezy.mdx
+++ b/content/docs/hooks/use-lemon-squeezy.mdx
@@ -1,0 +1,75 @@
+---
+title: useLemonSqueezy
+date: 2025-06-27
+description: Simplified integration with the LemonSqueezy checkout script.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-lemon-squeezy-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-lemon-squeezy"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-lemon-squeezy" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Props
+
+| Prop        | Type      | Default                                      | Description                        |
+| ----------- | --------- | -------------------------------------------- | ---------------------------------- |
+| `scriptUrl` | `string`  | `'https://app.lemonsqueezy.com/js/lemon.js'` | SDK script URL                     |
+| `autoInit`  | `boolean` | `true`                                       | Load script automatically on mount |
+
+## Data
+
+| Prop           | Type                    | Description                        |
+| -------------- | ----------------------- | ---------------------------------- |
+| `lemon`        | `any`                   | LemonSqueezy instance              |
+| `loading`      | `boolean`               | Indicates if the SDK is loading    |
+| `error`        | `Error \| null`         | Error loading the SDK              |
+| `init`         | `() => Promise<void>`   | Manually initialize the SDK        |
+| `openCheckout` | `(url: string) => void` | Open checkout for the provided URL |
+
+## Examples
+
+### Basic Usage
+
+```tsx
+const { openCheckout } = useLemonSqueezy();
+
+return (
+  <Button onClick={() => openCheckout('https://example.com/checkout')}>
+    Pay
+  </Button>
+);
+```
+
+## Related
+
+- [LemonSqueezy Docs](https://docs.lemonsqueezy.com/)

--- a/content/docs/hooks/use-mercadopago.mdx
+++ b/content/docs/hooks/use-mercadopago.mdx
@@ -1,0 +1,74 @@
+---
+title: useMercadoPago
+date: 2025-06-27
+description: Simple wrapper for MercadoPago Checkout.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-mercadopago-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-mercadopago"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-mercadopago" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Props
+
+| Prop        | Type      | Default   | Description                        |
+| ----------- | --------- | --------- | ---------------------------------- |
+| `publicKey` | `string`  | -         | MercadoPago public key             |
+| `locale`    | `string`  | `'en-US'` | SDK locale                         |
+| `autoInit`  | `boolean` | `true`    | Load script automatically on mount |
+
+## Data
+
+| Prop             | Type                             | Description                             |
+| ---------------- | -------------------------------- | --------------------------------------- |
+| `mp`             | `any`                            | MercadoPago instance                    |
+| `loading`        | `boolean`                        | Indicates if the SDK is loading         |
+| `error`          | `Error \| null`                  | Error loading the SDK                   |
+| `init`           | `() => Promise<void>`            | Manually initialize the SDK             |
+| `createCheckout` | `(preferenceId: string) => void` | Open checkout with the given preference |
+
+## Examples
+
+### Basic Usage
+
+```tsx
+const { createCheckout } = useMercadoPago({
+  publicKey: 'TEST-123',
+});
+
+return <Button onClick={() => createCheckout('pref_123')}>Pay</Button>;
+```
+
+## Related
+
+- [MercadoPago Checkout](https://www.mercadopago.com.br/developers/en/docs/checkout-pro)

--- a/content/docs/hooks/use-mova.mdx
+++ b/content/docs/hooks/use-mova.mdx
@@ -1,0 +1,40 @@
+---
+title: useMova
+date: 2025-06-27
+description: Mova payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-mova-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-mova"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-mova" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-nu-pay.mdx
+++ b/content/docs/hooks/use-nu-pay.mdx
@@ -1,0 +1,40 @@
+---
+title: useNuPay
+date: 2025-06-27
+description: Nu Pay integration hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-nu-pay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-nu-pay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-nu-pay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-pag-brasil.mdx
+++ b/content/docs/hooks/use-pag-brasil.mdx
@@ -1,0 +1,40 @@
+---
+title: usePagBrasil
+date: 2025-06-27
+description: PagBrasil payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-pag-brasil-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-pag-brasil"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-pag-brasil" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-pagarme.mdx
+++ b/content/docs/hooks/use-pagarme.mdx
@@ -1,0 +1,40 @@
+---
+title: usePagarme
+date: 2025-06-27
+description: Pagar.me payments hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-pagarme-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-pagarme"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-pagarme" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-pagbank.mdx
+++ b/content/docs/hooks/use-pagbank.mdx
@@ -1,0 +1,40 @@
+---
+title: usePagBank
+date: 2025-06-27
+description: PagBank payment widget helper.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-pagbank-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-pagbank"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-pagbank" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-pagseguro.mdx
+++ b/content/docs/hooks/use-pagseguro.mdx
@@ -1,0 +1,40 @@
+---
+title: usePagSeguro
+date: 2025-06-27
+description: PagSeguro checkout lightbox helper.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-pagseguro-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-pagseguro"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-pagseguro" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-payoneer.mdx
+++ b/content/docs/hooks/use-payoneer.mdx
@@ -1,0 +1,40 @@
+---
+title: usePayoneer
+date: 2025-06-27
+description: Simple Payoneer checkout helper.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-payoneer-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-payoneer"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-payoneer" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-paypal.mdx
+++ b/content/docs/hooks/use-paypal.mdx
@@ -1,0 +1,76 @@
+---
+title: usePayPal
+date: 2025-06-27
+description: Load the PayPal JS SDK and render buttons easily.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-paypal-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-paypal"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-paypal" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Props
+
+| Prop        | Type                                     | Default                           | Description                        |
+| ----------- | ---------------------------------------- | --------------------------------- | ---------------------------------- |
+| `clientId`  | `string`                                 | -                                 | PayPal client ID                   |
+| `currency`  | `string`                                 | `'USD'`                           | Currency for transactions          |
+| `intent`    | `'capture' \| 'authorize' \| 'tokenize'` | `'capture'`                       | Payment intent                     |
+| `scriptUrl` | `string`                                 | `'https://www.paypal.com/sdk/js'` | SDK script base URL                |
+| `autoInit`  | `boolean`                                | `true`                            | Load script automatically on mount |
+
+## Data
+
+| Prop            | Type                            | Description                     |
+| --------------- | ------------------------------- | ------------------------------- | ---------------------------------------- |
+| `paypal`        | `any`                           | PayPal namespace                |
+| `loading`       | `boolean`                       | Indicates if the SDK is loading |
+| `error`         | `Error \| null`                 | Error loading the SDK           |
+| `init`          | `() => Promise<void>`           | Manually initialize the SDK     |
+| `renderButtons` | `(config: any, selector: string | HTMLElement) => void`           | Render PayPal buttons into the container |
+
+## Examples
+
+### Basic Usage
+
+```tsx
+const { renderButtons } = usePayPal({ clientId: 'test123' });
+
+useEffect(() => {
+  renderButtons({}, '#paypal-container');
+}, [renderButtons]);
+```
+
+## Related
+
+- [PayPal JS SDK](https://developer.paypal.com/docs/business/javascript-sdk/)

--- a/content/docs/hooks/use-picpay.mdx
+++ b/content/docs/hooks/use-picpay.mdx
@@ -1,0 +1,40 @@
+---
+title: usePicPay
+date: 2025-06-27
+description: PicPay checkout hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-picpay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-picpay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-picpay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-safrapay.mdx
+++ b/content/docs/hooks/use-safrapay.mdx
@@ -1,0 +1,40 @@
+---
+title: useSafraPay
+date: 2025-06-27
+description: SafraPay checkout helper.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-safrapay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-safrapay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-safrapay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-square.mdx
+++ b/content/docs/hooks/use-square.mdx
@@ -1,0 +1,40 @@
+---
+title: useSquare
+date: 2025-06-27
+description: Square Web Payments SDK hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-square-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-square"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-square" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-stax-pay.mdx
+++ b/content/docs/hooks/use-stax-pay.mdx
@@ -1,0 +1,40 @@
+---
+title: useStaxPay
+date: 2025-06-27
+description: Stax Pay integration helper.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-stax-pay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-stax-pay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-stax-pay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-stone.mdx
+++ b/content/docs/hooks/use-stone.mdx
@@ -1,0 +1,40 @@
+---
+title: useStone
+date: 2025-06-27
+description: Stone payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-stone-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-stone"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-stone" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-stripe.mdx
+++ b/content/docs/hooks/use-stripe.mdx
@@ -1,0 +1,83 @@
+---
+title: useStripe
+date: 2025-06-27
+description: Wrapper around Stripe.js for easier payments integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-stripe-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-stripe"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-stripe" />
+
+<Step>Install the required dependencies.</Step>
+
+```bash
+pnpm add @stripe/stripe-js
+```
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Props
+
+| Prop             | Type                      | Default | Description                        |
+| ---------------- | ------------------------- | ------- | ---------------------------------- |
+| `publishableKey` | `string`                  | -       | Stripe publishable key             |
+| `stripeOptions`  | `Record<string, unknown>` | `{}`    | Options passed to `loadStripe`     |
+| `autoInit`       | `boolean`                 | `true`  | Load Stripe automatically on mount |
+
+## Data
+
+| Prop                 | Type                                                 | Description                    |
+| -------------------- | ---------------------------------------------------- | ------------------------------ |
+| `stripe`             | `Stripe \| null`                                     | Stripe instance                |
+| `loading`            | `boolean`                                            | Indicates if Stripe is loading |
+| `error`              | `Error \| null`                                      | Error loading the SDK          |
+| `init`               | `() => Promise<void>`                                | Manually initialize Stripe     |
+| `redirectToCheckout` | `(opts: any) => Promise<void>`                       | Redirect to checkout           |
+| `confirmCardPayment` | `(clientSecret: string, data?: any) => Promise<any>` | Confirm card payment           |
+
+## Examples
+
+### Basic Usage
+
+```tsx
+const { redirectToCheckout } = useStripe({
+  publishableKey: 'pk_test_...',
+});
+
+return (
+  <Button onClick={() => redirectToCheckout({ sessionId: '123' })}>Pay</Button>
+);
+```
+
+## Related
+
+- [Stripe.js Documentation](https://stripe.com/docs/js)

--- a/content/docs/hooks/use-superlogica.mdx
+++ b/content/docs/hooks/use-superlogica.mdx
@@ -1,0 +1,40 @@
+---
+title: useSuperlogica
+date: 2025-06-27
+description: Superlogica payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-superlogica-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-superlogica"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-superlogica" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-transire.mdx
+++ b/content/docs/hooks/use-transire.mdx
@@ -1,0 +1,40 @@
+---
+title: useTransire
+date: 2025-06-27
+description: Transire payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-transire-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-transire"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-transire" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-two-checkout.mdx
+++ b/content/docs/hooks/use-two-checkout.mdx
@@ -1,0 +1,40 @@
+---
+title: useTwoCheckout
+date: 2025-06-27
+description: 2Checkout integration hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-two-checkout-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-two-checkout"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-two-checkout" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-vindi.mdx
+++ b/content/docs/hooks/use-vindi.mdx
@@ -1,0 +1,40 @@
+---
+title: useVindi
+date: 2025-06-27
+description: Hook for integrating Vindi checkout.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-vindi-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-vindi"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-vindi" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-vr.mdx
+++ b/content/docs/hooks/use-vr.mdx
@@ -1,0 +1,40 @@
+---
+title: useVRPay
+date: 2025-06-27
+description: VR Pay integration hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-vr-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-vr"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-vr" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-wide-pay.mdx
+++ b/content/docs/hooks/use-wide-pay.mdx
@@ -1,0 +1,40 @@
+---
+title: useWidePay
+date: 2025-06-27
+description: Simple Wide Pay integration hook.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-wide-pay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-wide-pay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-wide-pay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-worldpay.mdx
+++ b/content/docs/hooks/use-worldpay.mdx
@@ -1,0 +1,40 @@
+---
+title: useWorldPay
+date: 2025-06-27
+description: WorldPay payments integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-worldpay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-worldpay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-worldpay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-yapay.mdx
+++ b/content/docs/hooks/use-yapay.mdx
@@ -1,0 +1,40 @@
+---
+title: useYapay
+date: 2025-06-27
+description: Yapay payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-yapay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-yapay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-yapay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-zigpay.mdx
+++ b/content/docs/hooks/use-zigpay.mdx
@@ -1,0 +1,40 @@
+---
+title: useZigpay
+date: 2025-06-27
+description: Zigpay payment integration.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-zigpay-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-zigpay"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-zigpay" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/content/docs/hooks/use-zoop.mdx
+++ b/content/docs/hooks/use-zoop.mdx
@@ -1,0 +1,40 @@
+---
+title: useZoop
+date: 2025-06-27
+description: Zoop payments helper.
+author: h3rmel
+published: true
+---
+
+<HookPreview name="use-zoop-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://guarahooks.com/r/use-zoop"
+```
+
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<HookSource name="use-zoop" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>

--- a/registry/example/use-abacate-pay-demo.tsx
+++ b/registry/example/use-abacate-pay-demo.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useAbacatePay } from '@/registry/hooks/use-abacate-pay';
+
+export default function UseAbacatePayDemo() {
+  const { abacate, loading, error, openCheckout } = useAbacatePay({
+    publicKey: 'test_public_key',
+  });
+
+  const handleCheckout = () => {
+    openCheckout('session-demo');
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>AbacatePay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!abacate || loading}>
+          {loading ? 'Loading...' : 'Pay with AbacatePay'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-acqio-demo.tsx
+++ b/registry/example/use-acqio-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useAcqio } from '@/registry/hooks/use-acqio';
+
+export default function UseAcqioDemo() {
+  const { provider, loading, error, init } = useAcqio();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Acqio</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-adyen-demo.tsx
+++ b/registry/example/use-adyen-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useAdyen } from '@/registry/hooks/use-adyen';
+
+export default function UseAdyenDemo() {
+  const { provider, loading, error, init } = useAdyen();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Adyen</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-ali-pay-demo.tsx
+++ b/registry/example/use-ali-pay-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useAliPay } from '@/registry/hooks/use-ali-pay';
+
+export default function UseAliPayDemo() {
+  const { alipay, loading, error, openCheckout } = useAliPay();
+
+  const handleCheckout = () => {
+    openCheckout({});
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>AliPay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!alipay || loading}>
+          {loading ? 'Loading...' : 'Open Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-amazon-pay-demo.tsx
+++ b/registry/example/use-amazon-pay-demo.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useAmazonPay } from '@/registry/hooks/use-amazon-pay';
+
+export default function UseAmazonPayDemo() {
+  const { amazon, loading, error, renderButton } = useAmazonPay({
+    merchantId: 'test',
+  });
+
+  useEffect(() => {
+    if (amazon) {
+      renderButton('#amazon-pay-button');
+    }
+  }, [amazon, renderButton]);
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Amazon Pay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div id="amazon-pay-button" />
+        {loading && <p className="text-sm">Loading...</p>}
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-apple-pay-demo.tsx
+++ b/registry/example/use-apple-pay-demo.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useApplePay } from '@/registry/hooks/use-apple-pay';
+
+export default function UseApplePayDemo() {
+  const { canMakePayments, startSession } = useApplePay({
+    countryCode: 'US',
+    currencyCode: 'USD',
+    merchantIdentifier: 'merchant.com.example',
+    supportedNetworks: ['visa', 'masterCard'],
+  });
+
+  const handlePay = () => {
+    const request = {
+      countryCode: 'US',
+      currencyCode: 'USD',
+      total: { label: 'Demo', amount: '1.00' },
+      supportedNetworks: ['visa', 'masterCard'],
+      merchantCapabilities: ['supports3DS'],
+    } as ApplePayPaymentRequest;
+    startSession(request);
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Apple Pay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handlePay} disabled={!canMakePayments}>
+          Pay with Apple Pay
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-barte-demo.tsx
+++ b/registry/example/use-barte-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useBarte } from '@/registry/hooks/use-barte';
+
+export default function UseBarteDemo() {
+  const { provider, loading, error, init } = useBarte();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Barte</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-boa-compra-demo.tsx
+++ b/registry/example/use-boa-compra-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useBoaCompra } from '@/registry/hooks/use-boa-compra';
+
+export default function UseBoaCompraDemo() {
+  const { provider, loading, error, init } = useBoaCompra();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Boa Compra</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-braintree-demo.tsx
+++ b/registry/example/use-braintree-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useBraintree } from '@/registry/hooks/use-braintree';
+
+export default function UseBraintreeDemo() {
+  const { provider, loading, error, init } = useBraintree();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Braintree</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-braspag-demo.tsx
+++ b/registry/example/use-braspag-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useBraspag } from '@/registry/hooks/use-braspag';
+
+export default function UseBraspagDemo() {
+  const { provider, loading, error, init } = useBraspag();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Braspag</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-cappta-demo.tsx
+++ b/registry/example/use-cappta-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useCappta } from '@/registry/hooks/use-cappta';
+
+export default function UseCapptaDemo() {
+  const { provider, loading, error, init } = useCappta();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Cappta</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-celcoin-demo.tsx
+++ b/registry/example/use-celcoin-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useCelcoin } from '@/registry/hooks/use-celcoin';
+
+export default function UseCelcoinDemo() {
+  const { provider, loading, error, init } = useCelcoin();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Celcoin</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-chargebee-demo.tsx
+++ b/registry/example/use-chargebee-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useChargebee } from '@/registry/hooks/use-chargebee';
+
+export default function UseChargebeeDemo() {
+  const { provider, loading, error, init } = useChargebee();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Chargebee</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-cielo-demo.tsx
+++ b/registry/example/use-cielo-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useCielo } from '@/registry/hooks/use-cielo';
+
+export default function UseCieloDemo() {
+  const { provider, loading, error, init } = useCielo();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Cielo</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-clearsale-demo.tsx
+++ b/registry/example/use-clearsale-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useClearSale } from '@/registry/hooks/use-clearsale';
+
+export default function UseClearSaleDemo() {
+  const { provider, loading, error, init } = useClearSale();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>ClearSale</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-cloud-walk-demo.tsx
+++ b/registry/example/use-cloud-walk-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useCloudWalk } from '@/registry/hooks/use-cloud-walk';
+
+export default function UseCloudWalkDemo() {
+  const { provider, loading, error, init } = useCloudWalk();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>CloudWalk</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-drip-demo.tsx
+++ b/registry/example/use-drip-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useDrip } from '@/registry/hooks/use-drip';
+
+export default function UseDripDemo() {
+  const { provider, loading, error, init } = useDrip();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Drip</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-ebanx-demo.tsx
+++ b/registry/example/use-ebanx-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useEbanx } from '@/registry/hooks/use-ebanx';
+
+export default function UseEbanxDemo() {
+  const { provider, loading, error, init } = useEbanx();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Ebanx</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-efi-bank-demo.tsx
+++ b/registry/example/use-efi-bank-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useEfiBank } from '@/registry/hooks/use-efi-bank';
+
+export default function UseEfiBankDemo() {
+  const { provider, loading, error, init } = useEfiBank();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Efi Bank</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-equals-demo.tsx
+++ b/registry/example/use-equals-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useEquals } from '@/registry/hooks/use-equals';
+
+export default function UseEqualsDemo() {
+  const { provider, loading, error, init } = useEquals();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Equals</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-gerenciament-demo.tsx
+++ b/registry/example/use-gerenciament-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useGerenciament } from '@/registry/hooks/use-gerenciament';
+
+export default function UseGerenciamentDemo() {
+  const { provider, loading, error, init } = useGerenciament();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Gerenciament</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-getnet-demo.tsx
+++ b/registry/example/use-getnet-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useGetnet } from '@/registry/hooks/use-getnet';
+
+export default function UseGetnetDemo() {
+  const { provider, loading, error, init } = useGetnet();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Getnet</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-iugu-demo.tsx
+++ b/registry/example/use-iugu-demo.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useIugu } from '@/registry/hooks/use-iugu';
+
+export default function UseIuguDemo() {
+  const { iugu, loading, error, createPaymentToken } = useIugu();
+
+  const handleToken = () => {
+    const form = document.createElement('form');
+    createPaymentToken(form, console.log);
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Iugu</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleToken} disabled={!iugu || loading}>
+          {loading ? 'Loading...' : 'Create Token'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-juno-demo.tsx
+++ b/registry/example/use-juno-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useJuno } from '@/registry/hooks/use-juno';
+
+export default function UseJunoDemo() {
+  const { provider, loading, error, init } = useJuno();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Juno</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-klap-demo.tsx
+++ b/registry/example/use-klap-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useKlap } from '@/registry/hooks/use-klap';
+
+export default function UseKlapDemo() {
+  const { provider, loading, error, init } = useKlap();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Klap</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-koin-demo.tsx
+++ b/registry/example/use-koin-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useKoin } from '@/registry/hooks/use-koin';
+
+export default function UseKoinDemo() {
+  const { provider, loading, error, init } = useKoin();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Koin</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-lemon-squeezy-demo.tsx
+++ b/registry/example/use-lemon-squeezy-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useLemonSqueezy } from '@/registry/hooks/use-lemon-squeezy';
+
+export default function UseLemonSqueezyDemo() {
+  const { lemon, loading, error, openCheckout } = useLemonSqueezy();
+
+  const handleCheckout = () => {
+    openCheckout('https://example.com/checkout');
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>LemonSqueezy Checkout</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!lemon || loading}>
+          {loading ? 'Loading...' : 'Open Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-mercadopago-demo.tsx
+++ b/registry/example/use-mercadopago-demo.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useMercadoPago } from '@/registry/hooks/use-mercadopago';
+
+export default function UseMercadoPagoDemo() {
+  const { mp, loading, error, createCheckout } = useMercadoPago({
+    publicKey: 'TEST-123',
+  });
+
+  const handleCheckout = () => {
+    createCheckout('demo-preference');
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>MercadoPago Checkout</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!mp || loading}>
+          {loading ? 'Loading...' : 'Open Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-mova-demo.tsx
+++ b/registry/example/use-mova-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useMova } from '@/registry/hooks/use-mova';
+
+export default function UseMovaDemo() {
+  const { provider, loading, error, init } = useMova();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Mova</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-nu-pay-demo.tsx
+++ b/registry/example/use-nu-pay-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useNuPay } from '@/registry/hooks/use-nu-pay';
+
+export default function UseNuPayDemo() {
+  const { provider, loading, error, init } = useNuPay();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Nu Pay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-pag-brasil-demo.tsx
+++ b/registry/example/use-pag-brasil-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { usePagBrasil } from '@/registry/hooks/use-pag-brasil';
+
+export default function UsePagBrasilDemo() {
+  const { provider, loading, error, init } = usePagBrasil();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>PagBrasil</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-pagarme-demo.tsx
+++ b/registry/example/use-pagarme-demo.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { usePagarme } from '@/registry/hooks/use-pagarme';
+
+export default function UsePagarmeDemo() {
+  const { pagarme, loading, error, createCardHash } = usePagarme();
+
+  const handleToken = async () => {
+    try {
+      const hash = await createCardHash({
+        key: 'pk_test',
+        number: '4111111111111111',
+        holder_name: 'Test',
+        exp_month: '12',
+        exp_year: '30',
+        cvv: '123',
+      });
+      console.log(hash);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Pagar.me</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleToken} disabled={!pagarme || loading}>
+          {loading ? 'Loading...' : 'Create Card Hash'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-pagbank-demo.tsx
+++ b/registry/example/use-pagbank-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { usePagBank } from '@/registry/hooks/use-pagbank';
+
+export default function UsePagBankDemo() {
+  const { pagbank, loading, error, openWidget } = usePagBank();
+
+  const handleCheckout = () => {
+    openWidget('demo-token');
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>PagBank</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!pagbank || loading}>
+          {loading ? 'Loading...' : 'Open Widget'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-pagseguro-demo.tsx
+++ b/registry/example/use-pagseguro-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { usePagSeguro } from '@/registry/hooks/use-pagseguro';
+
+export default function UsePagSeguroDemo() {
+  const { pagseguro, loading, error, openLightbox } = usePagSeguro();
+
+  const handleCheckout = () => {
+    openLightbox('demo-code');
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>PagSeguro</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!pagseguro || loading}>
+          {loading ? 'Loading...' : 'Open Lightbox'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-payoneer-demo.tsx
+++ b/registry/example/use-payoneer-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { usePayoneer } from '@/registry/hooks/use-payoneer';
+
+export default function UsePayoneerDemo() {
+  const { payoneer, loading, error, openCheckout } = usePayoneer();
+
+  const handleCheckout = () => {
+    openCheckout({});
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Payoneer</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!payoneer || loading}>
+          {loading ? 'Loading...' : 'Open Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-paypal-demo.tsx
+++ b/registry/example/use-paypal-demo.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { usePayPal } from '@/registry/hooks/use-paypal';
+
+export default function UsePayPalDemo() {
+  const { paypal, loading, error, renderButtons } = usePayPal({
+    clientId: 'test',
+  });
+
+  useEffect(() => {
+    if (paypal) {
+      renderButtons({}, '#paypal-button-container');
+    }
+  }, [paypal, renderButtons]);
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>PayPal Checkout</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div id="paypal-button-container" />
+        {loading && <p className="text-sm">Loading...</p>}
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-picpay-demo.tsx
+++ b/registry/example/use-picpay-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { usePicPay } from '@/registry/hooks/use-picpay';
+
+export default function UsePicPayDemo() {
+  const { provider, loading, error, init } = usePicPay();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>PicPay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-safrapay-demo.tsx
+++ b/registry/example/use-safrapay-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useSafraPay } from '@/registry/hooks/use-safrapay';
+
+export default function UseSafraPayDemo() {
+  const { provider, loading, error, init } = useSafraPay();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>SafraPay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-square-demo.tsx
+++ b/registry/example/use-square-demo.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useSquare } from '@/registry/hooks/use-square';
+
+export default function UseSquareDemo() {
+  const { square, loading, error, init } = useSquare({
+    applicationId: 'sandbox',
+    locationId: 'test',
+  });
+
+  const handleInit = () => {
+    init();
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Square Payments</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleInit} disabled={loading}>
+          {loading ? 'Loading...' : square ? 'Initialized' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-stax-pay-demo.tsx
+++ b/registry/example/use-stax-pay-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useStaxPay } from '@/registry/hooks/use-stax-pay';
+
+export default function UseStaxPayDemo() {
+  const { stax, loading, error, openCheckout } = useStaxPay();
+
+  const handleCheckout = () => {
+    openCheckout({});
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Stax Pay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!stax || loading}>
+          {loading ? 'Loading...' : 'Open Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-stone-demo.tsx
+++ b/registry/example/use-stone-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useStone } from '@/registry/hooks/use-stone';
+
+export default function UseStoneDemo() {
+  const { provider, loading, error, init } = useStone();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Stone</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-stripe-demo.tsx
+++ b/registry/example/use-stripe-demo.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useStripe } from '@/registry/hooks/use-stripe';
+
+export default function UseStripeDemo() {
+  const { stripe, loading, error, redirectToCheckout } = useStripe({
+    publishableKey: 'pk_test_12345',
+  });
+  const [message, setMessage] = useState('');
+
+  const handleCheckout = async () => {
+    try {
+      await redirectToCheckout({ sessionId: 'demo-session' });
+      setMessage('Redirecting...');
+    } catch (err) {
+      console.error(err);
+      setMessage('Failed to start checkout');
+    }
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Stripe Checkout</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!stripe || loading}>
+          {loading ? 'Loading...' : 'Start Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {message && <p className="text-sm">{message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-superlogica-demo.tsx
+++ b/registry/example/use-superlogica-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useSuperlogica } from '@/registry/hooks/use-superlogica';
+
+export default function UseSuperlogicaDemo() {
+  const { provider, loading, error, init } = useSuperlogica();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Superlogica</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-transire-demo.tsx
+++ b/registry/example/use-transire-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useTransire } from '@/registry/hooks/use-transire';
+
+export default function UseTransireDemo() {
+  const { provider, loading, error, init } = useTransire();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Transire</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-two-checkout-demo.tsx
+++ b/registry/example/use-two-checkout-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useTwoCheckout } from '@/registry/hooks/use-two-checkout';
+
+export default function UseTwoCheckoutDemo() {
+  const { twoCo, loading, error, openCheckout } = useTwoCheckout();
+
+  const handleCheckout = () => {
+    openCheckout({});
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>2Checkout</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!twoCo || loading}>
+          {loading ? 'Loading...' : 'Open Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-vindi-demo.tsx
+++ b/registry/example/use-vindi-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useVindi } from '@/registry/hooks/use-vindi';
+
+export default function UseVindiDemo() {
+  const { vindi, loading, error, openCheckout } = useVindi();
+
+  const handleCheckout = () => {
+    openCheckout({});
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Vindi Checkout</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!vindi || loading}>
+          {loading ? 'Loading...' : 'Open Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-vr-demo.tsx
+++ b/registry/example/use-vr-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useVRPay } from '@/registry/hooks/use-vr';
+
+export default function UseVRPayDemo() {
+  const { provider, loading, error, init } = useVRPay();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>VR</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-wide-pay-demo.tsx
+++ b/registry/example/use-wide-pay-demo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useWidePay } from '@/registry/hooks/use-wide-pay';
+
+export default function UseWidePayDemo() {
+  const { widepay, loading, error, openCheckout } = useWidePay();
+
+  const handleCheckout = () => {
+    openCheckout({});
+  };
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Wide Pay Checkout</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={handleCheckout} disabled={!widepay || loading}>
+          {loading ? 'Loading...' : 'Open Checkout'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-worldpay-demo.tsx
+++ b/registry/example/use-worldpay-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useWorldPay } from '@/registry/hooks/use-worldpay';
+
+export default function UseWorldPayDemo() {
+  const { provider, loading, error, init } = useWorldPay();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>WorldPay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-yapay-demo.tsx
+++ b/registry/example/use-yapay-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useYapay } from '@/registry/hooks/use-yapay';
+
+export default function UseYapayDemo() {
+  const { provider, loading, error, init } = useYapay();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Yapay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-zigpay-demo.tsx
+++ b/registry/example/use-zigpay-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useZigpay } from '@/registry/hooks/use-zigpay';
+
+export default function UseZigpayDemo() {
+  const { provider, loading, error, init } = useZigpay();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Zigpay</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/example/use-zoop-demo.tsx
+++ b/registry/example/use-zoop-demo.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useZoop } from '@/registry/hooks/use-zoop';
+
+export default function UseZoopDemo() {
+  const { provider, loading, error, init } = useZoop();
+
+  return (
+    <Card className="max-w-sm w-full">
+      <CardHeader>
+        <CardTitle>Zoop</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button onClick={init} disabled={loading}>
+          {loading ? 'Loading...' : 'Init'}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error.message}</p>}
+        {provider && <p className="text-sm">SDK loaded</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/registry/hooks/use-abacate-pay.tsx
+++ b/registry/hooks/use-abacate-pay.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseAbacatePayOptions {
+  publicKey: string;
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseAbacatePayReturn {
+  abacate: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openCheckout: (sessionId: string) => void;
+  getStatus: (paymentId: string) => Promise<any>;
+}
+
+export function useAbacatePay(
+  options: UseAbacatePayOptions,
+): UseAbacatePayReturn {
+  const {
+    publicKey,
+    scriptUrl = 'https://cdn.abacatepay.com/sdk.js',
+    autoInit = true,
+  } = options;
+
+  const [abacate, setAbacate] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).AbacatePay) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise((resolve, reject) => {
+        script.onload = resolve;
+        script.onerror = reject;
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      const instance = new (window as any).AbacatePay(publicKey);
+      setAbacate(instance);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [publicKey, loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openCheckout = useCallback(
+    (sessionId: string) => {
+      if (!abacate) throw new Error('AbacatePay not initialized');
+      abacate.openCheckout(sessionId);
+    },
+    [abacate],
+  );
+
+  const getStatus = useCallback(
+    async (paymentId: string) => {
+      if (!abacate) throw new Error('AbacatePay not initialized');
+      return abacate.getStatus(paymentId);
+    },
+    [abacate],
+  );
+
+  return { abacate, loading, error, init, openCheckout, getStatus };
+}

--- a/registry/hooks/use-acqio.tsx
+++ b/registry/hooks/use-acqio.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseAcqioOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseAcqioReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useAcqio(options: UseAcqioOptions = {}): UseAcqioReturn {
+  const { scriptUrl = 'https://api.acqio.com.br/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Acqio']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Acqio SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Acqio']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-adyen.tsx
+++ b/registry/hooks/use-adyen.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseAdyenOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseAdyenReturn {
+  adyen: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useAdyen(options: UseAdyenOptions = {}): UseAdyenReturn {
+  const {
+    scriptUrl = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/5.33.0/adyen.js',
+    autoInit = true,
+  } = options;
+
+  const [adyen, setAdyen] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).AdyenCheckout) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Adyen SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setAdyen((window as any).AdyenCheckout);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { adyen, loading, error, init };
+}

--- a/registry/hooks/use-ali-pay.tsx
+++ b/registry/hooks/use-ali-pay.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseAliPayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseAliPayReturn {
+  alipay: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openCheckout: (config?: any) => void;
+}
+
+export function useAliPay(options: UseAliPayOptions = {}): UseAliPayReturn {
+  const {
+    scriptUrl = 'https://a.alipayobjects.com/g/tripoli/tripoli.js',
+    autoInit = true,
+  } = options;
+
+  const [alipay, setAliPay] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).AlipayJSBridge) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load AliPay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setAliPay((window as any).AlipayJSBridge);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openCheckout = useCallback(
+    (config?: any) => {
+      if (!alipay) throw new Error('AliPay not initialized');
+      if (alipay.tradePay) {
+        alipay.tradePay(config);
+      }
+    },
+    [alipay],
+  );
+
+  return { alipay, loading, error, init, openCheckout };
+}

--- a/registry/hooks/use-amazon-pay.tsx
+++ b/registry/hooks/use-amazon-pay.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseAmazonPayOptions {
+  merchantId: string;
+  publicKeyId?: string;
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseAmazonPayReturn {
+  amazon: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  renderButton: (selector: string, options?: any) => void;
+}
+
+export function useAmazonPay(options: UseAmazonPayOptions): UseAmazonPayReturn {
+  const {
+    merchantId,
+    publicKeyId,
+    scriptUrl = 'https://static-na.payments-amazon.com/checkout.js',
+    autoInit = true,
+  } = options;
+
+  const [amazon, setAmazon] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).amazon) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load Amazon Pay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setAmazon((window as any).amazon);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const renderButton = useCallback(
+    (selector: string, opts?: any) => {
+      if (!amazon) throw new Error('Amazon Pay not initialized');
+      const container = document.querySelector(selector);
+      if (!container) throw new Error('Invalid container');
+      amazon.Pay.renderButton(container, {
+        merchantId,
+        publicKeyId,
+        ...opts,
+      });
+    },
+    [amazon, merchantId, publicKeyId],
+  );
+
+  return { amazon, loading, error, init, renderButton };
+}

--- a/registry/hooks/use-apple-pay.tsx
+++ b/registry/hooks/use-apple-pay.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseApplePayOptions {
+  countryCode: string;
+  currencyCode: string;
+  merchantIdentifier: string;
+  supportedNetworks: string[];
+  merchantCapabilities?: string[];
+}
+
+export interface UseApplePayReturn {
+  canMakePayments: boolean;
+  session: ApplePaySession | null;
+  startSession: (request: ApplePayPaymentRequest) => void;
+}
+
+export function useApplePay(options: UseApplePayOptions): UseApplePayReturn {
+  const [canMakePayments, setCanMakePayments] = useState(false);
+  const [session, setSession] = useState<ApplePaySession | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && (window as any).ApplePaySession) {
+      setCanMakePayments((window as any).ApplePaySession.canMakePayments());
+    }
+  }, []);
+
+  const startSession = useCallback((request: ApplePayPaymentRequest) => {
+    if (typeof window === 'undefined' || !(window as any).ApplePaySession) {
+      throw new Error('Apple Pay is not available');
+    }
+    const appleSession = new (window as any).ApplePaySession(3, request);
+    setSession(appleSession);
+    appleSession.begin();
+  }, []);
+
+  return { canMakePayments, session, startSession };
+}

--- a/registry/hooks/use-barte.tsx
+++ b/registry/hooks/use-barte.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseBarteOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseBarteReturn {
+  barte: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useBarte(options: UseBarteOptions = {}): UseBarteReturn {
+  const { scriptUrl = 'https://cdn.barte.com.br/barte.js', autoInit = true } =
+    options;
+
+  const [barte, setBarte] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Barte) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Barte SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setBarte((window as any).Barte);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { barte, loading, error, init };
+}

--- a/registry/hooks/use-boa-compra.tsx
+++ b/registry/hooks/use-boa-compra.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseBoaCompraOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseBoaCompraReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useBoaCompra(
+  options: UseBoaCompraOptions = {},
+): UseBoaCompraReturn {
+  const { scriptUrl = 'https://static.boacompra.com/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['BoaCompra']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load BoaCompra SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['BoaCompra']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-braintree.tsx
+++ b/registry/hooks/use-braintree.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseBraintreeOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseBraintreeReturn {
+  braintree: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useBraintree(
+  options: UseBraintreeOptions = {},
+): UseBraintreeReturn {
+  const {
+    scriptUrl = 'https://js.braintreegateway.com/web/dropin/1.35.0/js/dropin.min.js',
+    autoInit = true,
+  } = options;
+
+  const [braintree, setBraintree] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).braintree) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load Braintree SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setBraintree((window as any).braintree);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { braintree, loading, error, init };
+}

--- a/registry/hooks/use-braspag.tsx
+++ b/registry/hooks/use-braspag.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseBraspagOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseBraspagReturn {
+  braspag: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useBraspag(options: UseBraspagOptions = {}): UseBraspagReturn {
+  const {
+    scriptUrl = 'https://mpg.braspag.com.br/braspag.js',
+    autoInit = true,
+  } = options;
+
+  const [braspag, setBraspag] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Braspag) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Braspag SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setBraspag((window as any).Braspag);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { braspag, loading, error, init };
+}

--- a/registry/hooks/use-cappta.tsx
+++ b/registry/hooks/use-cappta.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseCapptaOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseCapptaReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useCappta(options: UseCapptaOptions = {}): UseCapptaReturn {
+  const { scriptUrl = 'https://cdn.cappta.com.br/cappta.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Cappta']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Cappta SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Cappta']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-celcoin.tsx
+++ b/registry/hooks/use-celcoin.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseCelcoinOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseCelcoinReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useCelcoin(options: UseCelcoinOptions = {}): UseCelcoinReturn {
+  const {
+    scriptUrl = 'https://static.celcoin.com.br/sdk.js',
+    autoInit = true,
+  } = options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Celcoin']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Celcoin SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Celcoin']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-chargebee.tsx
+++ b/registry/hooks/use-chargebee.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseChargebeeOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseChargebeeReturn {
+  chargebee: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useChargebee(
+  options: UseChargebeeOptions = {},
+): UseChargebeeReturn {
+  const {
+    scriptUrl = 'https://js.chargebee.com/v2/chargebee.js',
+    autoInit = true,
+  } = options;
+
+  const [chargebee, setChargebee] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Chargebee) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load Chargebee SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setChargebee((window as any).Chargebee);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { chargebee, loading, error, init };
+}

--- a/registry/hooks/use-cielo.tsx
+++ b/registry/hooks/use-cielo.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseCieloOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseCieloReturn {
+  cielo: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useCielo(options: UseCieloOptions = {}): UseCieloReturn {
+  const {
+    scriptUrl = 'https://assets.cielo.com.br/cielo.min.js',
+    autoInit = true,
+  } = options;
+
+  const [cielo, setCielo] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Cielo) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Cielo SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setCielo((window as any).Cielo);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { cielo, loading, error, init };
+}

--- a/registry/hooks/use-clearsale.tsx
+++ b/registry/hooks/use-clearsale.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseClearSaleOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseClearSaleReturn {
+  clearsale: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useClearSale(
+  options: UseClearSaleOptions = {},
+): UseClearSaleReturn {
+  const {
+    scriptUrl = 'https://device.clearsale.com.br/scripts/anti-fraud.min.js',
+    autoInit = true,
+  } = options;
+
+  const [clearsale, setClearSale] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).ClearSale) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load ClearSale SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setClearSale((window as any).ClearSale);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { clearsale, loading, error, init };
+}

--- a/registry/hooks/use-cloud-walk.tsx
+++ b/registry/hooks/use-cloud-walk.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseCloudWalkOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseCloudWalkReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useCloudWalk(
+  options: UseCloudWalkOptions = {},
+): UseCloudWalkReturn {
+  const { scriptUrl = 'https://cdn.cloudwalk.com/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['CloudWalk']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load CloudWalk SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['CloudWalk']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-drip.tsx
+++ b/registry/hooks/use-drip.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseDripOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseDripReturn {
+  drip: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useDrip(options: UseDripOptions = {}): UseDripReturn {
+  const { scriptUrl = 'https://cdn.drip.com/js/drip.js', autoInit = true } =
+    options;
+
+  const [drip, setDrip] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Drip) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Drip SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setDrip((window as any).Drip);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { drip, loading, error, init };
+}

--- a/registry/hooks/use-ebanx.tsx
+++ b/registry/hooks/use-ebanx.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseEbanxOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseEbanxReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useEbanx(options: UseEbanxOptions = {}): UseEbanxReturn {
+  const { scriptUrl = 'https://js.ebanx.com.br/ebanx.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Ebanx']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Ebanx SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Ebanx']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-efi-bank.tsx
+++ b/registry/hooks/use-efi-bank.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseEfiBankOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseEfiBankReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useEfiBank(options: UseEfiBankOptions = {}): UseEfiBankReturn {
+  const {
+    scriptUrl = 'https://sandbox.efipay.com.br/efi.js',
+    autoInit = true,
+  } = options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['EfiBank']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load EfiBank SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['EfiBank']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-equals.tsx
+++ b/registry/hooks/use-equals.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseEqualsOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseEqualsReturn {
+  equals: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useEquals(options: UseEqualsOptions = {}): UseEqualsReturn {
+  const { scriptUrl = 'https://cdn.equals.com/equals.js', autoInit = true } =
+    options;
+
+  const [equals, setEquals] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).EqualsPay) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Equals SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setEquals((window as any).EqualsPay);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { equals, loading, error, init };
+}

--- a/registry/hooks/use-gerenciament.tsx
+++ b/registry/hooks/use-gerenciament.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseGerenciamentOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseGerenciamentReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useGerenciament(
+  options: UseGerenciamentOptions = {},
+): UseGerenciamentReturn {
+  const { scriptUrl = 'https://cdn.gerenciament.com/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Gerenciament']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load Gerenciament SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Gerenciament']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-getnet.tsx
+++ b/registry/hooks/use-getnet.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseGetnetOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseGetnetReturn {
+  getnet: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useGetnet(options: UseGetnetOptions = {}): UseGetnetReturn {
+  const {
+    scriptUrl = 'https://payment.getnet.com.br/sdk/js',
+    autoInit = true,
+  } = options;
+
+  const [getnet, setGetnet] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Getnet) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Getnet SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setGetnet((window as any).Getnet);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { getnet, loading, error, init };
+}

--- a/registry/hooks/use-iugu.tsx
+++ b/registry/hooks/use-iugu.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseIuguOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseIuguReturn {
+  iugu: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  createPaymentToken: (
+    form: HTMLFormElement,
+    callback: (response: any) => void,
+  ) => void;
+}
+
+export function useIugu(options: UseIuguOptions = {}): UseIuguReturn {
+  const { scriptUrl = 'https://js.iugu.com/v2', autoInit = true } = options;
+
+  const [iugu, setIugu] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Iugu) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Iugu SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setIugu((window as any).Iugu);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const createPaymentToken = useCallback(
+    (form: HTMLFormElement, callback: (response: any) => void) => {
+      if (!iugu) throw new Error('Iugu not initialized');
+      iugu.createPaymentToken(form, callback);
+    },
+    [iugu],
+  );
+
+  return { iugu, loading, error, init, createPaymentToken };
+}

--- a/registry/hooks/use-juno.tsx
+++ b/registry/hooks/use-juno.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseJunoOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseJunoReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useJuno(options: UseJunoOptions = {}): UseJunoReturn {
+  const { scriptUrl = 'https://checkout.juno.com.br/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Juno']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Juno SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Juno']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-klap.tsx
+++ b/registry/hooks/use-klap.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseKlapOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseKlapReturn {
+  klap: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useKlap(options: UseKlapOptions = {}): UseKlapReturn {
+  const { scriptUrl = 'https://klap.app/klap.js', autoInit = true } = options;
+
+  const [klap, setKlap] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Klap) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Klap SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setKlap((window as any).Klap);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { klap, loading, error, init };
+}

--- a/registry/hooks/use-koin.tsx
+++ b/registry/hooks/use-koin.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseKoinOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseKoinReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useKoin(options: UseKoinOptions = {}): UseKoinReturn {
+  const { scriptUrl = 'https://static.koin.com.br/koin.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Koin']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Koin SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Koin']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-lemon-squeezy.tsx
+++ b/registry/hooks/use-lemon-squeezy.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseLemonSqueezyOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseLemonSqueezyReturn {
+  lemon: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openCheckout: (url: string) => void;
+}
+
+export function useLemonSqueezy(
+  options: UseLemonSqueezyOptions = {},
+): UseLemonSqueezyReturn {
+  const {
+    scriptUrl = 'https://app.lemonsqueezy.com/js/lemon.js',
+    autoInit = true,
+  } = options;
+
+  const [lemon, setLemon] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).LemonSqueezy) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load LemonSqueezy SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setLemon((window as any).LemonSqueezy);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openCheckout = useCallback(
+    (url: string) => {
+      if (!lemon) throw new Error('LemonSqueezy not initialized');
+      lemon.open({ checkout: url });
+    },
+    [lemon],
+  );
+
+  return { lemon, loading, error, init, openCheckout };
+}

--- a/registry/hooks/use-mercadopago.tsx
+++ b/registry/hooks/use-mercadopago.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseMercadoPagoOptions {
+  publicKey: string;
+  locale?: string;
+  autoInit?: boolean;
+}
+
+export interface UseMercadoPagoReturn {
+  mp: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  createCheckout: (preferenceId: string) => void;
+}
+
+export function useMercadoPago(
+  options: UseMercadoPagoOptions,
+): UseMercadoPagoReturn {
+  const { publicKey, locale = 'en-US', autoInit = true } = options;
+  const [mp, setMp] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).MercadoPago) {
+      const script = document.createElement('script');
+      script.src = 'https://sdk.mercadopago.com/js/v2';
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise((resolve, reject) => {
+        script.onload = resolve;
+        script.onerror = reject;
+      });
+    }
+  }, []);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      const instance = new (window as any).MercadoPago(publicKey, { locale });
+      setMp(instance);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [publicKey, locale, loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const createCheckout = useCallback(
+    (preferenceId: string) => {
+      if (!mp) throw new Error('MercadoPago not initialized');
+      mp.checkout({ preference: { id: preferenceId } });
+    },
+    [mp],
+  );
+
+  return { mp, loading, error, init, createCheckout };
+}

--- a/registry/hooks/use-mova.tsx
+++ b/registry/hooks/use-mova.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseMovaOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseMovaReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useMova(options: UseMovaOptions = {}): UseMovaReturn {
+  const { scriptUrl = 'https://cdn.mova.com/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Mova']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Mova SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Mova']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-nu-pay.tsx
+++ b/registry/hooks/use-nu-pay.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseNuPayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseNuPayReturn {
+  nupay: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useNuPay(options: UseNuPayOptions = {}): UseNuPayReturn {
+  const {
+    scriptUrl = 'https://assets.nubank.com.br/nupay.js',
+    autoInit = true,
+  } = options;
+
+  const [nupay, setNuPay] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).NuPay) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load NuPay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setNuPay((window as any).NuPay);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { nupay, loading, error, init };
+}

--- a/registry/hooks/use-pag-brasil.tsx
+++ b/registry/hooks/use-pag-brasil.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UsePagBrasilOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UsePagBrasilReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function usePagBrasil(
+  options: UsePagBrasilOptions = {},
+): UsePagBrasilReturn {
+  const { scriptUrl = 'https://cdn.pagbrasil.com.br/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['PagBrasil']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load PagBrasil SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['PagBrasil']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-pagarme.tsx
+++ b/registry/hooks/use-pagarme.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UsePagarmeOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UsePagarmeReturn {
+  pagarme: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  createCardHash: (card: any) => Promise<string>;
+}
+
+export function usePagarme(options: UsePagarmeOptions = {}): UsePagarmeReturn {
+  const {
+    scriptUrl = 'https://assets.pagar.me/pagarme-js/4.16/pagarme.min.js',
+    autoInit = true,
+  } = options;
+
+  const [pagarme, setPagarme] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).pagarme) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Pagar.me SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setPagarme((window as any).pagarme);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const createCardHash = useCallback(
+    async (card: any) => {
+      if (!pagarme) throw new Error('Pagar.me not initialized');
+      const client = await pagarme.client.connect({ encryption_key: card.key });
+      return client.security.encrypt(card);
+    },
+    [pagarme],
+  );
+
+  return { pagarme, loading, error, init, createCardHash };
+}

--- a/registry/hooks/use-pagbank.tsx
+++ b/registry/hooks/use-pagbank.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UsePagBankOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UsePagBankReturn {
+  pagbank: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openWidget: (token: string) => void;
+}
+
+export function usePagBank(options: UsePagBankOptions = {}): UsePagBankReturn {
+  const {
+    scriptUrl = 'https://assets.pagseguro.com.br/pgbank/js/pagbank.js',
+    autoInit = true,
+  } = options;
+
+  const [pagbank, setPagBank] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).PagBank) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load PagBank SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setPagBank((window as any).PagBank);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openWidget = useCallback(
+    (token: string) => {
+      if (!pagbank) throw new Error('PagBank not initialized');
+      pagbank.openWidget(token);
+    },
+    [pagbank],
+  );
+
+  return { pagbank, loading, error, init, openWidget };
+}

--- a/registry/hooks/use-pagseguro.tsx
+++ b/registry/hooks/use-pagseguro.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UsePagSeguroOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UsePagSeguroReturn {
+  pagseguro: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openLightbox: (code: string) => void;
+}
+
+export function usePagSeguro(
+  options: UsePagSeguroOptions = {},
+): UsePagSeguroReturn {
+  const {
+    scriptUrl = 'https://stc.pagseguro.uol.com.br/pagseguro/api/v2/checkout/pagseguro.directpayment.js',
+    autoInit = true,
+  } = options;
+
+  const [pagseguro, setPagSeguro] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).PagSeguroDirectPayment) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load PagSeguro SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setPagSeguro((window as any).PagSeguroDirectPayment);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openLightbox = useCallback(
+    (code: string) => {
+      if (!pagseguro) throw new Error('PagSeguro not initialized');
+      (window as any).PagSeguroLightbox({ code });
+    },
+    [pagseguro],
+  );
+
+  return { pagseguro, loading, error, init, openLightbox };
+}

--- a/registry/hooks/use-payoneer.tsx
+++ b/registry/hooks/use-payoneer.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UsePayoneerOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UsePayoneerReturn {
+  payoneer: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openCheckout: (config?: any) => void;
+}
+
+export function usePayoneer(
+  options: UsePayoneerOptions = {},
+): UsePayoneerReturn {
+  const {
+    scriptUrl = 'https://checkout.payoneer.com/checkout.js',
+    autoInit = true,
+  } = options;
+
+  const [payoneer, setPayoneer] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Payoneer) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Payoneer SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setPayoneer((window as any).Payoneer);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openCheckout = useCallback(
+    (config?: any) => {
+      if (!payoneer) throw new Error('Payoneer not initialized');
+      if (payoneer.openCheckout) {
+        payoneer.openCheckout(config);
+      }
+    },
+    [payoneer],
+  );
+
+  return { payoneer, loading, error, init, openCheckout };
+}

--- a/registry/hooks/use-paypal.tsx
+++ b/registry/hooks/use-paypal.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UsePayPalOptions {
+  clientId: string;
+  currency?: string;
+  intent?: 'capture' | 'authorize' | 'tokenize';
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UsePayPalReturn {
+  paypal: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  renderButtons: (config: any, selector: string | HTMLElement) => void;
+}
+
+export function usePayPal(options: UsePayPalOptions): UsePayPalReturn {
+  const {
+    clientId,
+    currency = 'USD',
+    intent = 'capture',
+    scriptUrl = 'https://www.paypal.com/sdk/js',
+    autoInit = true,
+  } = options;
+
+  const [paypal, setPayPal] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).paypal) {
+      const script = document.createElement('script');
+      const params = new URLSearchParams({
+        'client-id': clientId,
+        currency,
+        intent,
+      });
+      script.src = `${scriptUrl}?${params.toString()}`;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load PayPal SDK'));
+      });
+    }
+  }, [clientId, currency, intent, scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setPayPal((window as any).paypal);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const renderButtons = useCallback(
+    (config: any, selector: string | HTMLElement) => {
+      if (!paypal) throw new Error('PayPal SDK not initialized');
+      const container =
+        typeof selector === 'string'
+          ? document.querySelector(selector)
+          : selector;
+      if (!container) throw new Error('Invalid container for PayPal buttons');
+      paypal.Buttons(config).render(container as any);
+    },
+    [paypal],
+  );
+
+  return { paypal, loading, error, init, renderButtons };
+}

--- a/registry/hooks/use-picpay.tsx
+++ b/registry/hooks/use-picpay.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UsePicPayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UsePicPayReturn {
+  picpay: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function usePicPay(options: UsePicPayOptions = {}): UsePicPayReturn {
+  const {
+    scriptUrl = 'https://static.picpay.com.br/picpay.min.js',
+    autoInit = true,
+  } = options;
+
+  const [picpay, setPicPay] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).PicPay) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load PicPay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setPicPay((window as any).PicPay);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { picpay, loading, error, init };
+}

--- a/registry/hooks/use-safrapay.tsx
+++ b/registry/hooks/use-safrapay.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseSafraPayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseSafraPayReturn {
+  safrapay: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useSafraPay(
+  options: UseSafraPayOptions = {},
+): UseSafraPayReturn {
+  const {
+    scriptUrl = 'https://cdn.safrapay.com.br/safrapay.js',
+    autoInit = true,
+  } = options;
+
+  const [safrapay, setSafraPay] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).SafraPay) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load SafraPay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setSafraPay((window as any).SafraPay);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { safrapay, loading, error, init };
+}

--- a/registry/hooks/use-square.tsx
+++ b/registry/hooks/use-square.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseSquareOptions {
+  applicationId: string;
+  locationId: string;
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseSquareReturn {
+  square: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useSquare(options: UseSquareOptions): UseSquareReturn {
+  const {
+    applicationId,
+    locationId,
+    scriptUrl = 'https://web.squarecdn.com/v1/square.js',
+    autoInit = true,
+  } = options;
+
+  const [square, setSquare] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Square) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Square SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      const payments = (window as any).Square.payments(
+        applicationId,
+        locationId,
+      );
+      setSquare(payments);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [applicationId, locationId, loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { square, loading, error, init };
+}

--- a/registry/hooks/use-stax-pay.tsx
+++ b/registry/hooks/use-stax-pay.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseStaxPayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseStaxPayReturn {
+  stax: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openCheckout: (config?: any) => void;
+}
+
+export function useStaxPay(options: UseStaxPayOptions = {}): UseStaxPayReturn {
+  const { scriptUrl = 'https://js.staxpayments.com/stax.js', autoInit = true } =
+    options;
+
+  const [stax, setStax] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Stax) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Stax Pay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setStax((window as any).Stax);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openCheckout = useCallback(
+    (config?: any) => {
+      if (!stax) throw new Error('Stax Pay not initialized');
+      if (stax.openCheckout) {
+        stax.openCheckout(config);
+      }
+    },
+    [stax],
+  );
+
+  return { stax, loading, error, init, openCheckout };
+}

--- a/registry/hooks/use-stone.tsx
+++ b/registry/hooks/use-stone.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseStoneOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseStoneReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useStone(options: UseStoneOptions = {}): UseStoneReturn {
+  const { scriptUrl = 'https://sdk.stone.com.br/stone.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Stone']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Stone SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Stone']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-stripe.tsx
+++ b/registry/hooks/use-stripe.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseStripeOptions {
+  publishableKey: string;
+  stripeOptions?: Record<string, unknown>;
+  autoInit?: boolean;
+}
+
+export interface UseStripeReturn {
+  stripe: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  redirectToCheckout: (options: any) => Promise<void>;
+  confirmCardPayment: (clientSecret: string, data?: any) => Promise<any>;
+}
+
+export function useStripe(options: UseStripeOptions): UseStripeReturn {
+  const { publishableKey, stripeOptions = {}, autoInit = true } = options;
+  const [stripe, setStripe] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { loadStripe } = await import('@stripe/stripe-js');
+      const instance = await loadStripe(publishableKey, stripeOptions);
+      setStripe(instance);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [publishableKey, stripeOptions]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const redirectToCheckout = useCallback(
+    async (opts: any) => {
+      if (!stripe) throw new Error('Stripe not initialized');
+      await stripe.redirectToCheckout(opts);
+    },
+    [stripe],
+  );
+
+  const confirmCardPayment = useCallback(
+    async (clientSecret: string, data?: any) => {
+      if (!stripe) throw new Error('Stripe not initialized');
+      return stripe.confirmCardPayment(clientSecret, data);
+    },
+    [stripe],
+  );
+
+  return {
+    stripe,
+    loading,
+    error,
+    init,
+    redirectToCheckout,
+    confirmCardPayment,
+  };
+}

--- a/registry/hooks/use-superlogica.tsx
+++ b/registry/hooks/use-superlogica.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseSuperlogicaOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseSuperlogicaReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useSuperlogica(
+  options: UseSuperlogicaOptions = {},
+): UseSuperlogicaReturn {
+  const { scriptUrl = 'https://cdn.superlogica.com/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Superlogica']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load Superlogica SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Superlogica']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-transire.tsx
+++ b/registry/hooks/use-transire.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseTransireOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseTransireReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useTransire(
+  options: UseTransireOptions = {},
+): UseTransireReturn {
+  const { scriptUrl = 'https://cdn.transire.com.br/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Transire']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Transire SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Transire']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-two-checkout.tsx
+++ b/registry/hooks/use-two-checkout.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseTwoCheckoutOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseTwoCheckoutReturn {
+  twoCo: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openCheckout: (config?: any) => void;
+}
+
+export function useTwoCheckout(
+  options: UseTwoCheckoutOptions = {},
+): UseTwoCheckoutReturn {
+  const {
+    scriptUrl = 'https://www.2checkout.com/checkout/api/script/main.js',
+    autoInit = true,
+  } = options;
+
+  const [twoCo, setTwoCo] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).TCO) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error('Failed to load 2Checkout SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setTwoCo((window as any).TCO);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openCheckout = useCallback(
+    (config?: any) => {
+      if (!twoCo) throw new Error('2Checkout not initialized');
+      if (twoCo.load) {
+        twoCo.load();
+      }
+      if (twoCo.process) {
+        twoCo.process(config);
+      }
+    },
+    [twoCo],
+  );
+
+  return { twoCo, loading, error, init, openCheckout };
+}

--- a/registry/hooks/use-vindi.tsx
+++ b/registry/hooks/use-vindi.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseVindiOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseVindiReturn {
+  vindi: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openCheckout: (config?: any) => void;
+}
+
+export function useVindi(options: UseVindiOptions = {}): UseVindiReturn {
+  const {
+    scriptUrl = 'https://static.vindi.com.br/js/vindi-checkout.js',
+    autoInit = true,
+  } = options;
+
+  const [vindi, setVindi] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Vindi) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Vindi SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setVindi((window as any).Vindi);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openCheckout = useCallback(
+    (config?: any) => {
+      if (!vindi) throw new Error('Vindi not initialized');
+      if (vindi.openCheckout) {
+        vindi.openCheckout(config);
+      }
+    },
+    [vindi],
+  );
+
+  return { vindi, loading, error, init, openCheckout };
+}

--- a/registry/hooks/use-vr.tsx
+++ b/registry/hooks/use-vr.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseVRPayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseVRPayReturn {
+  vrpay: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useVRPay(options: UseVRPayOptions = {}): UseVRPayReturn {
+  const { scriptUrl = 'https://cdn.vr.com.br/vrpay.js', autoInit = true } =
+    options;
+
+  const [vrpay, setVrPay] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).VRPay) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load VR Pay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setVrPay((window as any).VRPay);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { vrpay, loading, error, init };
+}

--- a/registry/hooks/use-wide-pay.tsx
+++ b/registry/hooks/use-wide-pay.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseWidePayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseWidePayReturn {
+  widepay: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+  openCheckout: (config?: any) => void;
+}
+
+export function useWidePay(options: UseWidePayOptions = {}): UseWidePayReturn {
+  const { scriptUrl = 'https://cdn.widepay.com/client.js', autoInit = true } =
+    options;
+
+  const [widepay, setWidePay] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).WidePay) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Wide Pay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setWidePay((window as any).WidePay);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  const openCheckout = useCallback(
+    (config?: any) => {
+      if (!widepay) throw new Error('Wide Pay not initialized');
+      if (widepay.openCheckout) {
+        widepay.openCheckout(config);
+      }
+    },
+    [widepay],
+  );
+
+  return { widepay, loading, error, init, openCheckout };
+}

--- a/registry/hooks/use-worldpay.tsx
+++ b/registry/hooks/use-worldpay.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseWorldPayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseWorldPayReturn {
+  worldpay: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useWorldPay(
+  options: UseWorldPayOptions = {},
+): UseWorldPayReturn {
+  const {
+    scriptUrl = 'https://cdn.worldpay.com/v1/worldpay.js',
+    autoInit = true,
+  } = options;
+
+  const [worldpay, setWorldPay] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Worldpay) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load WorldPay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setWorldPay((window as any).Worldpay);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { worldpay, loading, error, init };
+}

--- a/registry/hooks/use-yapay.tsx
+++ b/registry/hooks/use-yapay.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseYapayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseYapayReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useYapay(options: UseYapayOptions = {}): UseYapayReturn {
+  const {
+    scriptUrl = 'https://static.yapay.com.br/yapay.js',
+    autoInit = true,
+  } = options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Yapay']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Yapay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Yapay']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-zigpay.tsx
+++ b/registry/hooks/use-zigpay.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseZigpayOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseZigpayReturn {
+  provider: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useZigpay(options: UseZigpayOptions = {}): UseZigpayReturn {
+  const { scriptUrl = 'https://cdn.zigpay.com/sdk.js', autoInit = true } =
+    options;
+
+  const [provider, setProvider] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any)['Zigpay']) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Zigpay SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setProvider((window as any)['Zigpay']);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { provider, loading, error, init };
+}

--- a/registry/hooks/use-zoop.tsx
+++ b/registry/hooks/use-zoop.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseZoopOptions {
+  scriptUrl?: string;
+  autoInit?: boolean;
+}
+
+export interface UseZoopReturn {
+  zoop: any;
+  loading: boolean;
+  error: Error | null;
+  init: () => Promise<void>;
+}
+
+export function useZoop(options: UseZoopOptions = {}): UseZoopReturn {
+  const {
+    scriptUrl = 'https://static.zoop.com.br/zoop-sdk.js',
+    autoInit = true,
+  } = options;
+
+  const [zoop, setZoop] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadScript = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!(window as any).Zoop) {
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      document.head.appendChild(script);
+      await new Promise<void>((resolve, reject) => {
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error('Failed to load Zoop SDK'));
+      });
+    }
+  }, [scriptUrl]);
+
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await loadScript();
+      setZoop((window as any).Zoop);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadScript]);
+
+  useEffect(() => {
+    if (autoInit) {
+      init();
+    }
+  }, [autoInit, init]);
+
+  return { zoop, loading, error, init };
+}

--- a/registry/registry-examples.ts
+++ b/registry/registry-examples.ts
@@ -831,4 +831,940 @@ export const examples: Registry['items'] = [
       },
     ],
   },
+  {
+    name: 'use-stripe-demo',
+    type: 'registry:example',
+    title: 'UseStripe Demo',
+    description: 'use-stripe in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-stripe.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-stripe-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-stripe-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-mercadopago-demo',
+    type: 'registry:example',
+    title: 'UseMercadoPago Demo',
+    description: 'use-mercadopago in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-mercadopago.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-mercadopago-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-mercadopago-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-abacate-pay-demo',
+    type: 'registry:example',
+    title: 'UseAbacatePay Demo',
+    description: 'use-abacate-pay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-abacate-pay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-abacate-pay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-abacate-pay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-lemon-squeezy-demo',
+    type: 'registry:example',
+    title: 'UseLemonSqueezy Demo',
+    description: 'use-lemon-squeezy in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-lemon-squeezy.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-lemon-squeezy-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-lemon-squeezy-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-paypal-demo',
+    type: 'registry:example',
+    title: 'UsePayPal Demo',
+    description: 'use-paypal in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-paypal.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-paypal-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-paypal-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-wide-pay-demo',
+    type: 'registry:example',
+    title: 'UseWidePay Demo',
+    description: 'use-wide-pay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-wide-pay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-wide-pay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-wide-pay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-vindi-demo',
+    type: 'registry:example',
+    title: 'UseVindi Demo',
+    description: 'use-vindi in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-vindi.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-vindi-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-vindi-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-apple-pay-demo',
+    type: 'registry:example',
+    title: 'UseApplePay Demo',
+    description: 'use-apple-pay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-apple-pay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-apple-pay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-apple-pay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-amazon-pay-demo',
+    type: 'registry:example',
+    title: 'UseAmazonPay Demo',
+    description: 'use-amazon-pay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-amazon-pay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-amazon-pay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-amazon-pay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-ali-pay-demo',
+    type: 'registry:example',
+    title: 'UseAliPay Demo',
+    description: 'use-ali-pay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-ali-pay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-ali-pay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-ali-pay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-two-checkout-demo',
+    type: 'registry:example',
+    title: 'UseTwoCheckout Demo',
+    description: 'use-two-checkout in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-two-checkout.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-two-checkout-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-two-checkout-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-stax-pay-demo',
+    type: 'registry:example',
+    title: 'UseStaxPay Demo',
+    description: 'use-stax-pay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-stax-pay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-stax-pay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-stax-pay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-square-demo',
+    type: 'registry:example',
+    title: 'UseSquare Demo',
+    description: 'use-square in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-square.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-square-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-square-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-payoneer-demo',
+    type: 'registry:example',
+    title: 'UsePayoneer Demo',
+    description: 'use-payoneer in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-payoneer.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-payoneer-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-payoneer-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-pagseguro-demo',
+    type: 'registry:example',
+    title: 'UsePagSeguro Demo',
+    description: 'use-pagseguro in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-pagseguro.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-pagseguro-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-pagseguro-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-pagbank-demo',
+    type: 'registry:example',
+    title: 'UsePagBank Demo',
+    description: 'use-pagbank in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-pagbank.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-pagbank-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-pagbank-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-iugu-demo',
+    type: 'registry:example',
+    title: 'UseIugu Demo',
+    description: 'use-iugu in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-iugu.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-iugu-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-iugu-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-pagarme-demo',
+    type: 'registry:example',
+    title: 'UsePagarme Demo',
+    description: 'use-pagarme in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-pagarme.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-pagarme-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-pagarme-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-drip-demo',
+    type: 'registry:example',
+    title: 'UseDrip Demo',
+    description: 'use-drip in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-drip.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-drip-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-drip-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-clearsale-demo',
+    type: 'registry:example',
+    title: 'UseClearSale Demo',
+    description: 'use-clearsale in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-clearsale.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-clearsale-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-clearsale-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-zoop-demo',
+    type: 'registry:example',
+    title: 'UseZoop Demo',
+    description: 'use-zoop in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-zoop.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-zoop-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-zoop-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-picpay-demo',
+    type: 'registry:example',
+    title: 'UsePicPay Demo',
+    description: 'use-picpay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-picpay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-picpay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-picpay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-adyen-demo',
+    type: 'registry:example',
+    title: 'UseAdyen Demo',
+    description: 'use-adyen in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-adyen.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-adyen-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-adyen-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-barte-demo',
+    type: 'registry:example',
+    title: 'UseBarte Demo',
+    description: 'use-barte in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-barte.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-barte-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-barte-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-braintree-demo',
+    type: 'registry:example',
+    title: 'UseBraintree Demo',
+    description: 'use-braintree in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-braintree.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-braintree-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-braintree-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-braspag-demo',
+    type: 'registry:example',
+    title: 'UseBraspag Demo',
+    description: 'use-braspag in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-braspag.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-braspag-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-braspag-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-cielo-demo',
+    type: 'registry:example',
+    title: 'UseCielo Demo',
+    description: 'use-cielo in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-cielo.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-cielo-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-cielo-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-chargebee-demo',
+    type: 'registry:example',
+    title: 'UseChargebee Demo',
+    description: 'use-chargebee in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-chargebee.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-chargebee-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-chargebee-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-getnet-demo',
+    type: 'registry:example',
+    title: 'UseGetnet Demo',
+    description: 'use-getnet in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-getnet.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-getnet-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-getnet-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-equals-demo',
+    type: 'registry:example',
+    title: 'UseEquals Demo',
+    description: 'use-equals in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-equals.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-equals-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-equals-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-klap-demo',
+    type: 'registry:example',
+    title: 'UseKlap Demo',
+    description: 'use-klap in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-klap.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-klap-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-klap-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-nu-pay-demo',
+    type: 'registry:example',
+    title: 'UseNuPay Demo',
+    description: 'use-nu-pay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-nu-pay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-nu-pay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-nu-pay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-safrapay-demo',
+    type: 'registry:example',
+    title: 'UseSafraPay Demo',
+    description: 'use-safrapay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-safrapay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-safrapay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-safrapay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-vr-demo',
+    type: 'registry:example',
+    title: 'UseVRPay Demo',
+    description: 'use-vr in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-vr.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-vr-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-vr-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-worldpay-demo',
+    type: 'registry:example',
+    title: 'UseWorldPay Demo',
+    description: 'use-worldpay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-worldpay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-worldpay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-worldpay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-transire-demo',
+    type: 'registry:example',
+    title: 'UseTransire Demo',
+    description: 'use-transire in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-transire.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-transire-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-transire-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-pag-brasil-demo',
+    type: 'registry:example',
+    title: 'UsePagBrasil Demo',
+    description: 'use-pag-brasil in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-pag-brasil.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-pag-brasil-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-pag-brasil-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-stone-demo',
+    type: 'registry:example',
+    title: 'UseStone Demo',
+    description: 'use-stone in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-stone.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-stone-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-stone-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-superlogica-demo',
+    type: 'registry:example',
+    title: 'UseSuperlogica Demo',
+    description: 'use-superlogica in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-superlogica.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-superlogica-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-superlogica-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-yapay-demo',
+    type: 'registry:example',
+    title: 'UseYapay Demo',
+    description: 'use-yapay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-yapay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-yapay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-yapay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-zigpay-demo',
+    type: 'registry:example',
+    title: 'UseZigpay Demo',
+    description: 'use-zigpay in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-zigpay.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-zigpay-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-zigpay-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-boa-compra-demo',
+    type: 'registry:example',
+    title: 'UseBoaCompra Demo',
+    description: 'use-boa-compra in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-boa-compra.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-boa-compra-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-boa-compra-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-celcoin-demo',
+    type: 'registry:example',
+    title: 'UseCelcoin Demo',
+    description: 'use-celcoin in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-celcoin.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-celcoin-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-celcoin-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-acqio-demo',
+    type: 'registry:example',
+    title: 'UseAcqio Demo',
+    description: 'use-acqio in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-acqio.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-acqio-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-acqio-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-cappta-demo',
+    type: 'registry:example',
+    title: 'UseCappta Demo',
+    description: 'use-cappta in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-cappta.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-cappta-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-cappta-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-ebanx-demo',
+    type: 'registry:example',
+    title: 'UseEbanx Demo',
+    description: 'use-ebanx in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-ebanx.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-ebanx-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-ebanx-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-gerenciament-demo',
+    type: 'registry:example',
+    title: 'UseGerenciament Demo',
+    description: 'use-gerenciament in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-gerenciament.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-gerenciament-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-gerenciament-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-juno-demo',
+    type: 'registry:example',
+    title: 'UseJuno Demo',
+    description: 'use-juno in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-juno.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-juno-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-juno-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-koin-demo',
+    type: 'registry:example',
+    title: 'UseKoin Demo',
+    description: 'use-koin in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-koin.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-koin-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-koin-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-mova-demo',
+    type: 'registry:example',
+    title: 'UseMova Demo',
+    description: 'use-mova in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-mova.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-mova-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-mova-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-cloud-walk-demo',
+    type: 'registry:example',
+    title: 'UseCloudWalk Demo',
+    description: 'use-cloud-walk in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-cloud-walk.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-cloud-walk-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-cloud-walk-demo.tsx',
+      },
+    ],
+  },
+  {
+    name: 'use-efi-bank-demo',
+    type: 'registry:example',
+    title: 'UseEfiBank Demo',
+    description: 'use-efi-bank in action.',
+    registryDependencies: [
+      'card',
+      'button',
+      'https://guarahooks.com/r/use-efi-bank.json',
+    ],
+    files: [
+      {
+        path: 'registry/example/use-efi-bank-demo.tsx',
+        type: 'registry:example',
+        target: 'components/example/use-efi-bank-demo.tsx',
+      },
+    ],
+  },
 ];

--- a/registry/registry-hooks.ts
+++ b/registry/registry-hooks.ts
@@ -639,4 +639,732 @@ export const hooks: Registry['items'] = [
     ],
     categories: ['forms'],
   },
+  {
+    name: 'use-stripe',
+    type: 'registry:hook',
+    title: 'UseStripe',
+    description: 'Stripe.js wrapper for payments.',
+    files: [
+      {
+        path: 'registry/hooks/use-stripe.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-stripe.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-mercadopago',
+    type: 'registry:hook',
+    title: 'UseMercadoPago',
+    description: 'MercadoPago checkout helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-mercadopago.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-mercadopago.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-abacate-pay',
+    type: 'registry:hook',
+    title: 'UseAbacatePay',
+    description: 'Hook for the AbacatePay gateway.',
+    files: [
+      {
+        path: 'registry/hooks/use-abacate-pay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-abacate-pay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-lemon-squeezy',
+    type: 'registry:hook',
+    title: 'UseLemonSqueezy',
+    description: 'LemonSqueezy checkout integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-lemon-squeezy.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-lemon-squeezy.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-paypal',
+    type: 'registry:hook',
+    title: 'UsePayPal',
+    description: 'PayPal JS SDK wrapper.',
+    files: [
+      {
+        path: 'registry/hooks/use-paypal.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-paypal.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-wide-pay',
+    type: 'registry:hook',
+    title: 'UseWidePay',
+    description: 'Wide Pay checkout integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-wide-pay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-wide-pay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-vindi',
+    type: 'registry:hook',
+    title: 'UseVindi',
+    description: 'Vindi checkout integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-vindi.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-vindi.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-apple-pay',
+    type: 'registry:hook',
+    title: 'UseApplePay',
+    description: 'Apple Pay helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-apple-pay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-apple-pay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-amazon-pay',
+    type: 'registry:hook',
+    title: 'UseAmazonPay',
+    description: 'Amazon Pay integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-amazon-pay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-amazon-pay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-ali-pay',
+    type: 'registry:hook',
+    title: 'UseAliPay',
+    description: 'AliPay integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-ali-pay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-ali-pay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-two-checkout',
+    type: 'registry:hook',
+    title: 'UseTwoCheckout',
+    description: '2Checkout integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-two-checkout.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-two-checkout.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-stax-pay',
+    type: 'registry:hook',
+    title: 'UseStaxPay',
+    description: 'Stax Pay integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-stax-pay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-stax-pay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-square',
+    type: 'registry:hook',
+    title: 'UseSquare',
+    description: 'Square payments integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-square.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-square.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-payoneer',
+    type: 'registry:hook',
+    title: 'UsePayoneer',
+    description: 'Payoneer checkout helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-payoneer.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-payoneer.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-pagseguro',
+    type: 'registry:hook',
+    title: 'UsePagSeguro',
+    description: 'PagSeguro checkout lightbox.',
+    files: [
+      {
+        path: 'registry/hooks/use-pagseguro.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-pagseguro.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-pagbank',
+    type: 'registry:hook',
+    title: 'UsePagBank',
+    description: 'PagBank widget integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-pagbank.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-pagbank.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-iugu',
+    type: 'registry:hook',
+    title: 'UseIugu',
+    description: 'Iugu checkout helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-iugu.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-iugu.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-pagarme',
+    type: 'registry:hook',
+    title: 'UsePagarme',
+    description: 'Pagar.me payments helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-pagarme.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-pagarme.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-drip',
+    type: 'registry:hook',
+    title: 'UseDrip',
+    description: 'Drip payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-drip.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-drip.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-clearsale',
+    type: 'registry:hook',
+    title: 'UseClearSale',
+    description: 'ClearSale anti-fraud helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-clearsale.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-clearsale.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-zoop',
+    type: 'registry:hook',
+    title: 'UseZoop',
+    description: 'Zoop payments integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-zoop.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-zoop.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-picpay',
+    type: 'registry:hook',
+    title: 'UsePicPay',
+    description: 'PicPay checkout helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-picpay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-picpay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-adyen',
+    type: 'registry:hook',
+    title: 'UseAdyen',
+    description: 'Adyen checkout integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-adyen.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-adyen.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-barte',
+    type: 'registry:hook',
+    title: 'UseBarte',
+    description: 'Barte payments helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-barte.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-barte.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-braintree',
+    type: 'registry:hook',
+    title: 'UseBraintree',
+    description: 'Braintree drop-in wrapper.',
+    files: [
+      {
+        path: 'registry/hooks/use-braintree.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-braintree.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-braspag',
+    type: 'registry:hook',
+    title: 'UseBraspag',
+    description: 'Braspag payments helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-braspag.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-braspag.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-cielo',
+    type: 'registry:hook',
+    title: 'UseCielo',
+    description: 'Cielo payments integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-cielo.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-cielo.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-chargebee',
+    type: 'registry:hook',
+    title: 'UseChargebee',
+    description: 'Chargebee integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-chargebee.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-chargebee.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-getnet',
+    type: 'registry:hook',
+    title: 'UseGetnet',
+    description: 'Getnet payment SDK.',
+    files: [
+      {
+        path: 'registry/hooks/use-getnet.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-getnet.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-equals',
+    type: 'registry:hook',
+    title: 'UseEquals',
+    description: 'Equals pay integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-equals.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-equals.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-klap',
+    type: 'registry:hook',
+    title: 'UseKlap',
+    description: 'Klap payments integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-klap.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-klap.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-nu-pay',
+    type: 'registry:hook',
+    title: 'UseNuPay',
+    description: 'Nu Pay helper.',
+    files: [
+      {
+        path: 'registry/hooks/use-nu-pay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-nu-pay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-safrapay',
+    type: 'registry:hook',
+    title: 'UseSafraPay',
+    description: 'SafraPay integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-safrapay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-safrapay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-vr',
+    type: 'registry:hook',
+    title: 'UseVRPay',
+    description: 'VR Pay integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-vr.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-vr.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-worldpay',
+    type: 'registry:hook',
+    title: 'UseWorldPay',
+    description: 'WorldPay SDK wrapper.',
+    files: [
+      {
+        path: 'registry/hooks/use-worldpay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-worldpay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-transire',
+    type: 'registry:hook',
+    title: 'UseTransire',
+    description: 'Transire payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-transire.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-transire.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-pag-brasil',
+    type: 'registry:hook',
+    title: 'UsePagBrasil',
+    description: 'PagBrasil payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-pag-brasil.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-pag-brasil.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-stone',
+    type: 'registry:hook',
+    title: 'UseStone',
+    description: 'Stone payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-stone.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-stone.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-superlogica',
+    type: 'registry:hook',
+    title: 'UseSuperlogica',
+    description: 'Superlogica payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-superlogica.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-superlogica.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-yapay',
+    type: 'registry:hook',
+    title: 'UseYapay',
+    description: 'Yapay payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-yapay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-yapay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-zigpay',
+    type: 'registry:hook',
+    title: 'UseZigpay',
+    description: 'Zigpay payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-zigpay.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-zigpay.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-boa-compra',
+    type: 'registry:hook',
+    title: 'UseBoaCompra',
+    description: 'Boa Compra payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-boa-compra.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-boa-compra.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-celcoin',
+    type: 'registry:hook',
+    title: 'UseCelcoin',
+    description: 'Celcoin payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-celcoin.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-celcoin.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-acqio',
+    type: 'registry:hook',
+    title: 'UseAcqio',
+    description: 'Acqio payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-acqio.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-acqio.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-cappta',
+    type: 'registry:hook',
+    title: 'UseCappta',
+    description: 'Cappta payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-cappta.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-cappta.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-ebanx',
+    type: 'registry:hook',
+    title: 'UseEbanx',
+    description: 'Ebanx payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-ebanx.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-ebanx.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-gerenciament',
+    type: 'registry:hook',
+    title: 'UseGerenciament',
+    description: 'Gerenciament payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-gerenciament.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-gerenciament.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-juno',
+    type: 'registry:hook',
+    title: 'UseJuno',
+    description: 'Juno payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-juno.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-juno.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-koin',
+    type: 'registry:hook',
+    title: 'UseKoin',
+    description: 'Koin payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-koin.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-koin.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-mova',
+    type: 'registry:hook',
+    title: 'UseMova',
+    description: 'Mova payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-mova.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-mova.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-cloud-walk',
+    type: 'registry:hook',
+    title: 'UseCloudWalk',
+    description: 'CloudWalk payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-cloud-walk.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-cloud-walk.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
+  {
+    name: 'use-efi-bank',
+    type: 'registry:hook',
+    title: 'UseEfiBank',
+    description: 'Efi Bank payment integration.',
+    files: [
+      {
+        path: 'registry/hooks/use-efi-bank.tsx',
+        type: 'registry:hook',
+        target: 'hooks/guarahooks/use-efi-bank.tsx',
+      },
+    ],
+    categories: ['payments'],
+  },
 ];


### PR DESCRIPTION
## Summary
- implement new payment hooks for providers like Transire, PagBrasil, Stone, Superlogica and many others
- register the hooks and examples in the registry
- document each new payment integration in the docs configuration

## Testing
- `pnpm lint:fix`
- `pnpm format:write` *(errors from import sort plugin, but files processed)*

------
https://chatgpt.com/codex/tasks/task_e_685efc1c0f5c8326a846902f1600f3f9